### PR TITLE
Add grafana_api_path to grafana_dashboard and grafana_datasource

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,15 @@ Example:
 
 ```
 
+
+#### Using Grafana in a reverse proxy environment
+
+When defining `grafana_dashboard` and / or `grafana_datasource` you have to make sure you
+set `grafana_api_path` according to your needs. By default this value is set to `/api`, if
+you are using a sub-path for Grafana, for instance `/grafana`, the `grafana_api_path` must
+be set to `/grafana/api`. Do not add a trailing `/` (slash) at the end of the value.
+
+
 #### Custom Types and Providers
 
 The module includes two custom types: `grafana_dashboard` and `grafana_datasource`
@@ -334,6 +343,7 @@ grafana_dashboard { 'example_dashboard':
   grafana_url       => 'http://localhost:3000',
   grafana_user      => 'admin',
   grafana_password  => '5ecretPassw0rd',
+  grafana_api_path  => '/api'
   content           => template('path/to/exported/file.json'),
 }
 ```
@@ -351,6 +361,7 @@ grafana_datasource { 'influxdb':
   grafana_url       => 'http://localhost:3000',
   grafana_user      => 'admin',
   grafana_password  => '5ecretPassw0rd',
+  grafana_api_path  => '/api'
   type              => 'influxdb',
   url               => 'http://localhost:8086',
   user              => 'admin',

--- a/lib/puppet/provider/grafana_dashboard/grafana.rb
+++ b/lib/puppet/provider/grafana_dashboard/grafana.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
 
   # Return the list of dashboards
   def dashboards
-    response = send_request('GET', '/api/search', nil, q: '', starred: false)
+    response = send_request('GET', format('%s/search', resource[:grafana_api_path]), nil, q: '', starred: false)
     if response.code != '200'
       raise format('Fail to retrieve the dashboards (HTTP response: %s/%s)', response.code, response.body)
     end
@@ -41,7 +41,7 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
   def find_dashboard
     return unless dashboards.find { |x| x['title'] == resource[:title] }
 
-    response = send_request format('GET, /api/dashboards/db/%s', slug)
+    response = send_request('GET', format('%s/dashboards/db/%s', resource[:grafana_api_path], slug))
     if response.code != '200'
       raise format('Fail to retrieve dashboard %s (HTTP response: %s/%s)', resource[:title], response.code, response.body)
     end
@@ -62,7 +62,7 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
       overwrite: !@dashboard.nil?
     }
 
-    response = send_request('POST', '/api/dashboards/db', data)
+    response = send_request('POST', format('%s/dashboards/db', resource[:grafana_api_path]), data)
     return unless response.code != '200'
     raise format('Fail to save dashboard %s (HTTP response: %s/%s', resource[:name], response.code, response.body)
   end
@@ -84,7 +84,7 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
   end
 
   def destroy
-    response = send_request format('DELETE, /api/dashboards/db/%s', slug)
+    response = send_request('DELETE', format('%s/dashboards/db/%s', resource[:grafana_api_path], slug))
 
     return unless response.code != '200'
     raise Puppet::Error, format('Failed to delete dashboard %s (HTTP response: %s/%s', resource[:title], response.code, response.body)

--- a/lib/puppet/provider/grafana_datasource/grafana.rb
+++ b/lib/puppet/provider/grafana_datasource/grafana.rb
@@ -22,7 +22,7 @@ Puppet::Type.type(:grafana_datasource).provide(:grafana, parent: Puppet::Provide
   defaultfor kernel: 'Linux'
 
   def datasources
-    response = send_request('GET', '/api/datasources')
+    response = send_request('GET', format('%s/datasources', resource[:grafana_api_path]))
     if response.code != '200'
       raise format('Fail to retrieve datasources (HTTP response: %s/%s)', response.code, response.body)
     end
@@ -31,7 +31,7 @@ Puppet::Type.type(:grafana_datasource).provide(:grafana, parent: Puppet::Provide
       datasources = JSON.parse(response.body)
 
       datasources.map { |x| x['id'] }.map do |id|
-        response = send_request 'GET', format('/api/datasources/%s', id)
+        response = send_request('GET', format('%s/datasources/%s', resource[:grafana_api_path], id))
         if response.code != '200'
           raise format('Fail to retrieve datasource %d (HTTP response: %s/%s)', id, response.code, response.body)
         end
@@ -153,10 +153,10 @@ Puppet::Type.type(:grafana_datasource).provide(:grafana, parent: Puppet::Provide
     }
 
     if datasource.nil?
-      response = send_request('POST', '/api/datasources', data)
+      response = send_request('POST', format('%s/datasources', resource[:grafana_api_path]), data)
     else
       data[:id] = datasource[:id]
-      response = send_request 'PUT', format('/api/datasources/%s', datasource[:id]), data
+      response = send_request('PUT', format('%s/datasources/%s', resource[:grafana_api_path], datasource[:id]), data)
     end
 
     if response.code != '200'
@@ -166,7 +166,7 @@ Puppet::Type.type(:grafana_datasource).provide(:grafana, parent: Puppet::Provide
   end
 
   def delete_datasource
-    response = send_request 'DELETE', format('/api/datasources/%s', datasource[:id])
+    response = send_request('DELETE', format('%s/datasources/%s', resource[:grafana_api_path], datasource[:id]))
 
     if response.code != '200'
       raise format('Failed to delete datasource %s (HTTP response: %s/%s', resource[:name], response.code, response.body)

--- a/lib/puppet/type/grafana_dashboard.rb
+++ b/lib/puppet/type/grafana_dashboard.rb
@@ -74,7 +74,7 @@ Puppet::Type.newtype(:grafana_dashboard) do
     defaultto '/api'
 
     validate do |value|
-      unless value =~ %r{^/.*\/api$}
+      unless value =~ %r{^/.*/?api$}
         raise ArgumentError, format('%s is not a valid API path', value)
       end
     end

--- a/lib/puppet/type/grafana_dashboard.rb
+++ b/lib/puppet/type/grafana_dashboard.rb
@@ -69,6 +69,17 @@ Puppet::Type.newtype(:grafana_dashboard) do
     desc 'The password for the Grafana server (optional)'
   end
 
+  newparam(:grafana_api_path) do
+    desc 'The absolute path to the API endpoint'
+    defaultto '/api'
+
+    validate do |value|
+      unless value =~ %r{^/.*\/api$}
+        raise ArgumentError, format('%s is not a valid API path', value)
+      end
+    end
+  end
+
   # rubocop:disable Style/SignalException
   validate do
     fail('content is required when ensure is present') if self[:ensure] == :present && self[:content].nil?

--- a/lib/puppet/type/grafana_datasource.rb
+++ b/lib/puppet/type/grafana_datasource.rb
@@ -40,6 +40,17 @@ Puppet::Type.newtype(:grafana_datasource) do
     desc 'The password for the Grafana server'
   end
 
+  newparam(:grafana_api_path) do
+    desc 'The absolute path to the API endpoint'
+    defaultto '/api'
+
+    validate do |value|
+      unless value =~ %r{^/.*\/api$}
+        raise ArgumentError, format('%s is not a valid API path', value)
+      end
+    end
+  end
+
   newproperty(:url) do
     desc 'The URL of the datasource'
 

--- a/lib/puppet/type/grafana_datasource.rb
+++ b/lib/puppet/type/grafana_datasource.rb
@@ -45,7 +45,7 @@ Puppet::Type.newtype(:grafana_datasource) do
     defaultto '/api'
 
     validate do |value|
-      unless value =~ %r{^/.*\/api$}
+      unless value =~ %r{^/.*/?api$}
         raise ArgumentError, format('%s is not a valid API path', value)
       end
     end


### PR DESCRIPTION
Adds a parameter `grafana_api_path` for `grafana_dashboard` and `grafana_datasource`. With this change we can now configure where the API endpoint is located at. Before this change it was not possible to use the module in a reverse proxy setup where grafana is not located at the root of a web server because the API endpoint was hardcoded to `/api`.

This way you can now install grafana alongside your already existing web site under a sub-path like e.g. `/stats`, `grafana_api_path` would then look like this: `/stats/api`. It's important to not include a trailing slash as this would mess up the format strings.
