### PR TITLE
The puppet 4-only release will start at 3.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-grafana",
-  "version": "2.6.2-rc0",
+  "version": "3.0.0-rc0",
   "author": "Vox Pupuli",
   "summary": "This module provides Grafana, a dashboard and graph editor for Graphite and InfluxDB.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Push any backports of 2.x to the `puppet3` branch.