### PR TITLE
makes grafana dashboard idempotent and add the option that a dashboard wont be enforced

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -430,6 +430,7 @@ Style/PerlBackrefs:
 
 Style/PredicateName:
   Enabled: True
+  NameWhitelist: is_to_s
 
 Style/RedundantException:
   Enabled: True

--- a/lib/puppet/provider/grafana_dashboard/grafana.rb
+++ b/lib/puppet/provider/grafana_dashboard/grafana.rb
@@ -40,7 +40,7 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
   # Return the dashboard matching with the resource's title
   def find_dashboard
     return unless dashboards.find { |x| x['title'] == resource[:title] }
-   
+
     response = send_request('GET', format('%s/dashboards/db/%s', resource[:grafana_api_path], slug))
     if response.code != '200'
       raise format('Fail to retrieve dashboard %s (HTTP response: %s/%s)', resource[:title], response.code, response.body)
@@ -73,17 +73,15 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
 
   def content
     if resource[:enforce_dashboard] == true
-      @dashboard.reject {|k,v| k =~ /^id|version|title$/}
+      @dashboard.reject {|k| k =~ %r{^id|version|title$} }
     else
       resource[:content]
     end
   end
 
   def content=(value)
-    if resource[:enforce_dashboard] == true
+    return unless resource[:enforce_dashboard] == true
       save_dashboard(value)
-    end
-    
   end
 
   def create

--- a/lib/puppet/provider/grafana_dashboard/grafana.rb
+++ b/lib/puppet/provider/grafana_dashboard/grafana.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
 
   # Return the list of dashboards
   def dashboards
-    response = send_request('GET', '/api/search', nil, q: '', starred: false)
+    response = send_request('GET', format('%s/search', resource[:grafana_api_path]), nil, q: '', starred: false)
     if response.code != '200'
       raise format('Fail to retrieve the dashboards (HTTP response: %s/%s)', response.code, response.body)
     end
@@ -40,8 +40,8 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
   # Return the dashboard matching with the resource's title
   def find_dashboard
     return unless dashboards.find { |x| x['title'] == resource[:title] }
-
-    response = send_request format('GET, /api/dashboards/db/%s', slug)
+   
+    response = send_request('GET', format('%s/dashboards/db/%s', resource[:grafana_api_path], slug))
     if response.code != '200'
       raise format('Fail to retrieve dashboard %s (HTTP response: %s/%s)', resource[:title], response.code, response.body)
     end
@@ -58,11 +58,11 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
     data = {
       dashboard: dashboard.merge('title' => resource[:title],
                                  'id' => @dashboard ? @dashboard['id'] : nil,
-                                 'version' => @dashboard ? @dashboard['version'] + 1 : 0),
+                                 'version' => @dashboard ? @dashboard['version'] + 1 : dashboard['version']),
       overwrite: !@dashboard.nil?
     }
 
-    response = send_request('POST', '/api/dashboards/db', data)
+    response = send_request('POST', format('%s/dashboards/db', resource[:grafana_api_path]), data)
     return unless response.code != '200'
     raise format('Fail to save dashboard %s (HTTP response: %s/%s', resource[:name], response.code, response.body)
   end
@@ -72,11 +72,18 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
   end
 
   def content
-    @dashboard
+    if resource[:enforce_dashboard] == true
+      @dashboard.reject {|k,v| k =~ /^id|version|title$/}
+    else
+      resource[:content]
+    end
   end
 
   def content=(value)
-    save_dashboard(value)
+    if resource[:enforce_dashboard] == true
+      save_dashboard(value)
+    end
+    
   end
 
   def create
@@ -84,7 +91,7 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
   end
 
   def destroy
-    response = send_request format('DELETE, /api/dashboards/db/%s', slug)
+    response = send_request('DELETE', format('%s/dashboards/db/%s', resource[:grafana_api_path], slug))
 
     return unless response.code != '200'
     raise Puppet::Error, format('Failed to delete dashboard %s (HTTP response: %s/%s', resource[:title], response.code, response.body)

--- a/lib/puppet/provider/grafana_dashboard/grafana.rb
+++ b/lib/puppet/provider/grafana_dashboard/grafana.rb
@@ -73,7 +73,7 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
 
   def content
     if resource[:enforce_dashboard] == true
-      @dashboard.reject {|k| k =~ %r{^id|version|title$} }
+      @dashboard.reject { |k| k =~ %r{^id|version|title$} }
     else
       resource[:content]
     end
@@ -81,7 +81,7 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
 
   def content=(value)
     return unless resource[:enforce_dashboard] == true
-      save_dashboard(value)
+    save_dashboard(value)
   end
 
   def create

--- a/lib/puppet/provider/grafana_datasource/grafana.rb
+++ b/lib/puppet/provider/grafana_datasource/grafana.rb
@@ -22,7 +22,7 @@ Puppet::Type.type(:grafana_datasource).provide(:grafana, parent: Puppet::Provide
   defaultfor kernel: 'Linux'
 
   def datasources
-    response = send_request('GET', '/api/datasources')
+    response = send_request('GET', format('%s/datasources', resource[:grafana_api_path]))
     if response.code != '200'
       raise format('Fail to retrieve datasources (HTTP response: %s/%s)', response.code, response.body)
     end
@@ -31,7 +31,7 @@ Puppet::Type.type(:grafana_datasource).provide(:grafana, parent: Puppet::Provide
       datasources = JSON.parse(response.body)
 
       datasources.map { |x| x['id'] }.map do |id|
-        response = send_request 'GET', format('/api/datasources/%s', id)
+        response = send_request('GET', format('%s/datasources/%s', resource[:grafana_api_path], id))
         if response.code != '200'
           raise format('Fail to retrieve datasource %d (HTTP response: %s/%s)', id, response.code, response.body)
         end
@@ -153,10 +153,10 @@ Puppet::Type.type(:grafana_datasource).provide(:grafana, parent: Puppet::Provide
     }
 
     if datasource.nil?
-      response = send_request('POST', '/api/datasources', data)
+      response = send_request('POST', format('%s/datasources', resource[:grafana_api_path]), data)
     else
       data[:id] = datasource[:id]
-      response = send_request 'PUT', format('/api/datasources/%s', datasource[:id]), data
+      response = send_request('PUT', format('%s/datasources/%s', resource[:grafana_api_path], datasource[:id]), data)
     end
 
     if response.code != '200'
@@ -166,7 +166,7 @@ Puppet::Type.type(:grafana_datasource).provide(:grafana, parent: Puppet::Provide
   end
 
   def delete_datasource
-    response = send_request 'DELETE', format('/api/datasources/%s', datasource[:id])
+    response = send_request('DELETE', format('%s/datasources/%s', resource[:grafana_api_path], datasource[:id]))
 
     if response.code != '200'
       raise format('Failed to delete datasource %s (HTTP response: %s/%s', resource[:name], response.code, response.body)

--- a/lib/puppet/type/grafana_dashboard.rb
+++ b/lib/puppet/type/grafana_dashboard.rb
@@ -25,10 +25,9 @@ Puppet::Type.newtype(:grafana_dashboard) do
 
   newproperty(:content) do
     desc 'The JSON representation of the dashboard.'
-    
+
     validate do |value|
       begin
-        
         JSON.parse(value)
       rescue JSON::ParserError
         raise ArgumentError, 'Invalid JSON string for content'
@@ -36,8 +35,7 @@ Puppet::Type.newtype(:grafana_dashboard) do
     end
 
     munge do |value|
-      value
-      value = JSON.parse(value).reject {|k,v| k =~ /^id|version|title$/}
+      value = JSON.parse(value).reject { |k| k =~ %r{^id|version|title$} }
       value.sort.to_h
     end
 
@@ -45,14 +43,13 @@ Puppet::Type.newtype(:grafana_dashboard) do
       if value.length > 12
         "#{value.to_s.slice(0, 12)}..."
       else
-          value
+        value
       end
     end
 
-    def is_to_s(value) 
+    def is_to_s(value)
       should_to_s(value)
     end
-
   end
 
   newparam(:grafana_url) do
@@ -73,7 +70,7 @@ Puppet::Type.newtype(:grafana_dashboard) do
   newparam(:grafana_password) do
     desc 'The password for the Grafana server (optional)'
   end
-  
+
   newparam(:grafana_api_path) do
     desc 'The absolute path to the API endpoint'
     defaultto '/api'
@@ -83,10 +80,10 @@ Puppet::Type.newtype(:grafana_dashboard) do
         raise ArgumentError, format('%s is not a valid API path', value)
       end
     end
-end
-  
-  newparam(:enforce_dashboard, :boolean => true, :parent => Puppet::Parameter::Boolean) do
-    desc 'Boolean if the Dashboard should be overwriten (optional)'
+  end
+
+  newparam(:enforce_dashboard, boolean: true, parent: Puppet::Parameter::Boolean) do
+    desc 'Boolean if the Dashboard should be enforced or not (optional)'
     defaultto true
   end
 

--- a/lib/puppet/type/grafana_datasource.rb
+++ b/lib/puppet/type/grafana_datasource.rb
@@ -39,16 +39,16 @@ Puppet::Type.newtype(:grafana_datasource) do
   newparam(:grafana_password) do
     desc 'The password for the Grafana server'
   end
-  
+
   newparam(:grafana_api_path) do
-      desc 'The absolute path to the API endpoint'
-      defaultto '/api'
-  
-      validate do |value|
-        unless value =~ %r{^/.*/?api$}
-          raise ArgumentError, format('%s is not a valid API path', value)
-        end
+    desc 'The absolute path to the API endpoint'
+    defaultto '/api'
+
+    validate do |value|
+      unless value =~ %r{^/.*/?api$}
+        raise ArgumentError, format('%s is not a valid API path', value)
       end
+    end
   end
 
   newproperty(:url) do
@@ -94,7 +94,7 @@ Puppet::Type.newtype(:grafana_datasource) do
     desc 'Additional JSON data to configure the datasource (optional)'
 
     validate do |value|
-      unless value.nil? || !value.is_a?(Hash)
+      unless value.nil? || value.is_a?(Hash)
         raise ArgumentError, 'json_data should be a Hash!'
       end
     end

--- a/lib/puppet/type/grafana_datasource.rb
+++ b/lib/puppet/type/grafana_datasource.rb
@@ -39,6 +39,17 @@ Puppet::Type.newtype(:grafana_datasource) do
   newparam(:grafana_password) do
     desc 'The password for the Grafana server'
   end
+  
+  newparam(:grafana_api_path) do
+      desc 'The absolute path to the API endpoint'
+      defaultto '/api'
+  
+      validate do |value|
+        unless value =~ %r{^/.*/?api$}
+          raise ArgumentError, format('%s is not a valid API path', value)
+        end
+      end
+  end
 
   newproperty(:url) do
     desc 'The URL of the datasource'
@@ -83,7 +94,7 @@ Puppet::Type.newtype(:grafana_datasource) do
     desc 'Additional JSON data to configure the datasource (optional)'
 
     validate do |value|
-      unless value.nil? || value.is_a?(Hash)
+      unless value.nil? || !value.is_a?(Hash)
         raise ArgumentError, 'json_data should be a Hash!'
       end
     end


### PR DESCRIPTION
fixes previews breakage, makes grafana dashboard idempotent and add the option that a dashboard wont be enforced

sorry its my first contrib on github and my first time to mangle with pupptet types and providers

this commit:
+ integrates pull request #17 
+ fixes current state of the type and provider 
+ makes the grafana_dashboar type idempotent.. you can basicly paste the json directly from grafana (tested with grafana 3 and 4)
+ adds the feature if a dashboard schould be enforced if it has been changed (our usecase is that we backup the dashboards and want to keep a way to change it without puppet rewriting it every time )


<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
