### PR TITLE
FIX configuration file ownership

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,6 +11,8 @@ class grafana::config {
         file {  $::grafana::cfg_location:
           ensure  => file,
           content => template('grafana/config.ini.erb'),
+          owner   => 'grafana',
+          group   => 'grafana',
         }
       }
     }
@@ -20,6 +22,8 @@ class grafana::config {
       file {  $::grafana::cfg_location:
         ensure  => file,
         content => template('grafana/config.ini.erb'),
+        owner   => 'grafana',
+        group   => 'grafana',
       }
     }
     'archive': {
@@ -28,6 +32,8 @@ class grafana::config {
       file { "${::grafana::install_dir}/conf/custom.ini":
         ensure  => file,
         content => template('grafana/config.ini.erb'),
+        owner   => 'grafana',
+        group   => 'grafana',
       }
     }
     default: {
@@ -40,6 +46,8 @@ class grafana::config {
     file { '/etc/grafana/ldap.toml':
       ensure  => file,
       content => inline_template("<%= require 'toml'; TOML::Generator.new(@ldap_cfg).body %>\n"),
+      owner   => 'grafana',
+      group   => 'grafana',
     }
   }
 }


### PR DESCRIPTION
Depending on the default ownership and permissions of the Puppet run, the
configuration might be unreadable by the grafana user, causing the service
startup to fail.

One such possible cause is if the file type has default permissions such as:

```
File {
  owner => 'root',
  group => 'root',
  mode  => '0600',
}
```

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
