### PR TITLE
implement package_ensure param for archlinux

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -123,7 +123,7 @@ class grafana::install {
             fail('manage_package_repo is not supported on Archlinux')
           }
           package { $::grafana::package_name:
-            ensure  => $::grafana::version, # pacman provider doesn't have feature versionable
+            ensure  => 'present', # pacman provider doesn't have feature versionable
           }
         }
         default: {

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -127,6 +127,10 @@ describe 'grafana' do
           describe 'install the package' do
             it { is_expected.to contain_package('grafana').with_ensure('present') }
           end
+        when 'Archlinux'
+          describe 'install the package' do
+            it { is_expected.to contain_package('grafana').with_ensure('present') }
+          end
         end
       end
 

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -26,6 +26,7 @@ describe 'grafana' do
       end
       context 'with default values' do
         it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('grafana') }
         it { is_expected.to contain_anchor('grafana::begin') }
         it { is_expected.to contain_class('grafana::params') }
         it { is_expected.to contain_class('grafana::install') }


### PR DESCRIPTION
we can't pass the grafana version to the archlinux package provider. it
has no versionable feature. this adds a workaround to provide 'present'
to it. This can later be extended to pass explicit states to the other
operating systems as well, or to implement ensure=>absent. We can't set
the $version variable to 'present' because this will kill the other
installation methods.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
