### PR TITLE
Debian and RedHat based operating systems should use the repository by default

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -99,7 +99,7 @@ class grafana::install {
           if ( $::grafana::manage_package_repo ){
             yumrepo { 'grafana':
               descr    => 'grafana repo',
-              baseurl  => "https://packagecloud.io/grafana/stable/el/${::operatingsystemmajrelease}/\$basearch",
+              baseurl  => "https://packagecloud.io/grafana/${::grafana::repo_name}/el/${::operatingsystemmajrelease}/\$basearch",
               gpgcheck => 1,
               gpgkey   => 'https://packagecloud.io/gpg.key https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana',
               enabled  => 1,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,12 @@ class grafana::params {
       $cfg_location        = '/etc/grafana.ini'
       $service_name        = 'grafana'
     }
+    'Debian', 'RedHat': {
+      $manage_package_repo = true
+      $install_method      = 'repo'
+      $cfg_location        = '/etc/grafana/grafana.ini'
+      $service_name        = 'grafana-server'
+    }
     default: {
       $manage_package_repo = true
       $install_method      = 'package'

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -36,6 +36,12 @@ describe 'grafana' do
       end
 
       context 'with parameter install_method is set to package' do
+        let(:params) do
+          {
+            install_method: 'package'
+          }
+        end
+
         case facts[:osfamily]
         when 'Debian'
           download_location = '/tmp/grafana.deb'


### PR DESCRIPTION
We should use the repository by default to get updates automatically.