### PR TITLE
Always use jessie apt repo when osfamily is Debian.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -75,7 +75,7 @@ class grafana::install {
             }
             apt::source { 'grafana':
               location => "https://packagecloud.io/grafana/${::grafana::repo_name}/debian",
-              release  => $::lsbdistcodename,
+              release  => 'jessie',
               repos    => 'main',
               key      =>  {
                 'id'     => '418A7F2FB0E1E6E7EABF6FE8C2E73424D59097AB',

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -81,7 +81,7 @@ describe 'grafana' do
         when 'Debian'
           describe 'install apt repo dependencies first' do
             it { is_expected.to contain_class('apt') }
-            it { is_expected.to contain_apt__source('grafana').with(release: facts[:lsbdistcodename], repos: 'main', location: 'https://packagecloud.io/grafana/stable/debian') }
+            it { is_expected.to contain_apt__source('grafana').with(release: 'jessie', repos: 'main', location: 'https://packagecloud.io/grafana/stable/debian') }
             it { is_expected.to contain_apt__source('grafana').that_comes_before('Package[grafana]') }
           end
 


### PR DESCRIPTION
After trying to set up grafana on Ubuntu 14.04 using this module, I noticed the `apt::source` is configured with `$::lsbdistcodename`, which creates a broken source file (`deb https://packagecloud.io/grafana/stable/debian trusty main` returns a 404). The [grafana docs](http://docs.grafana.org/installation/debian/) states `deb https://packagecloud.io/grafana/stable/debian/ jessie main` should be used.
> Even if you are on Ubuntu or another Debian version, according to docs.grafana.org/installation/debian.
>
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
