### PR TITLE
Fix path to grafana-cli in manifests/plugin.pp.

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -4,7 +4,7 @@ define grafana::plugin(
   String $plugin = $title,
 ){
   exec{"install ${plugin}":
-    command => "/usr/bin/grafana-cli plugins install ${plugin}",
+    command => "/usr/sbin/grafana-cli plugins install ${plugin}",
     creates => "/var/lib/grafana/plugins/${plugin}",
   }
 }


### PR DESCRIPTION
On my Debian 8 system the grafana package has grafana-cli under /usr/sbin,
not /usr/bin.  I don't have any experience with grafana, so I don't know if this is something that never worked, or if the grafana packaging has changed at some point.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
