### PR TITLE
Fix typo in provider

### DIFF
--- a/lib/puppet/provider/grafana.rb
+++ b/lib/puppet/provider/grafana.rb
@@ -68,7 +68,7 @@ class Puppet::Provider::Grafana < Puppet::Provider
     end
 
     request.content_type = 'application/json'
-    if resource[:grafana_user] && resource[:grafana_user]
+    if resource[:grafana_user] && resource[:grafana_password]
       request.basic_auth resource[:grafana_user], resource[:grafana_password]
     end
 


### PR DESCRIPTION
This appears to have been broken since the initial commit in 3e672bb32b163b697a67a5936703c7dcd17a77dd.

Ether typo should be fixed or redundant predicate removed.