### PR TITLE
BREAKING: Update default Grafana version to 4.5.1 and improve acceptance tests

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,6 +1,9 @@
 ---
 .travis.yml:
   secure: "qtLA1TPKaVgd9rvi0kkF2v0CP0QLls//lFHJ9IowTYNi5O+0dx7OxZCK3g4nkNWWbsujS464/YFJqVRWoXIeLIyFtfMKkaRAiuaukxOQqnzD+BsnpYYeo2zeZPCvMbB94+7G7JQ+jpuzlsHX6j+H6LQEj6+kXzd8NAj8rlygrL8XcFN3bA8XM/unCvqn2b2sduShExVl0mnNMIvZMHCbdrEzByXkz+FmyGYCay+feDIYbIbhzYLNnh6BcDkq24TxRmVOdEnUkPG6ZU0UJlNqBZB++zAIazR25NyX+b22/CFp6D6YJKkJvBNnywGUNNF21s4a6kPoEnUVBEO6yg5sDkKgp8nAvsmUnI8A1tfRFWKejxHZN3YqveY60xiNIUEHJU4MjEE6VVi9WpNW8CpJbfP/z3RtlU5n4ckSER7mb/ApxspUPJRzyMKjobDP12WU/bgXinzdNMu6PH9H56WkDpRNtIYnNhIAuirdfDr2Ok5z9/9yObUt/OQddM4wrOnMG7lyyUIzAO2OOJbIcOaZBedTKccpCu6k2mOkUHhMutf1D0bde5IGhrs7E54V2ZNxX5Dopv5eOrmVN2OxdcB9g8nmISxX6Tty/BNrTBvt7urthGjUJrjlnNE/K1595KmcWa6PGWUcYZyzdKeWqiA3+iWKSmnx1Ri0lsml5Z/a4QM="
+  docker_sets:
+    - set: docker/ubuntu-16.04
+    - set: docker/centos-7
 Gemfile:
   optional:
     ':test':

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,18 @@ script:
 matrix:
   fast_finish: true
   include:
+  - rvm: 2.4.1
+    bundler_args: --without development
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/ubuntu-14.04 CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.4.1
+    bundler_args: --without development
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/centos-7 CHECK=beaker
+    services: docker
+    sudo: required
   - rvm: 2.1.9
     bundler_args: --without system_tests development
     env: PUPPET_VERSION="~> 4.0" CHECK=test

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :system_tests do
   end
   gem 'serverspec',                    :require => false
   gem 'beaker-puppet_install_helper',  :require => false
+  gem 'beaker-module_install_helper',  :require => false
 end
 
 
@@ -63,7 +64,7 @@ end
 if facterversion = ENV['FACTER_GEM_VERSION']
   gem 'facter', facterversion.to_s, :require => false, :groups => [:test]
 else
-gem 'facter', :require => false, :groups => [:test]
+  gem 'facter', :require => false, :groups => [:test]
 end
 
 ENV['PUPPET_VERSION'].nil? ? puppetversion = '~> 5.0' : puppetversion = ENV['PUPPET_VERSION'].to_s

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 1. [Overview](#overview)
 1. [Module Description](#module-description)
 1. [Setup](#setup)
+    * [Requirements](#requirements)
     * [Beginning with Grafana](#beginning-with-grafana)
 1. [Usage](#usage)
     * [Classes and Defined Types](#classes-and-defined-types)
@@ -39,6 +40,15 @@ This module will:
 * Allow you to override the version of Grafana to be installed, and / or the
   package source
 * Perform basic configuration of Grafana
+
+### Requirements
+
+* If using an operating system of the Debian-based family, and the "repo"
+`install_method`, you will need to ensure that
+[puppetlabs-apt](https://forge.puppet.com/puppetlabs/apt) version 4.x is
+installed.
+* If using Docker, you will need the
+[garethr/docker](https://forge.puppet.com/garethr/docker) module version 5.x
 
 ### Beginning with Grafana
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,9 +92,11 @@ class grafana (
     fail('cfg parameter must be a hash')
   }
 
-  anchor { 'grafana::begin': }
-  -> class { '::grafana::install': }
-  -> class { '::grafana::config': }
-  ~> class { '::grafana::service': }
-  -> anchor { 'grafana::end': }
+  contain grafana::install
+  contain grafana::config
+  contain grafana::service
+
+  Class['grafana::install']
+  -> Class['grafana::config']
+  ~> Class['grafana::service']
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,11 +1,12 @@
 # == Class grafana::install
 #
 class grafana::install {
+  $base_url = 'https://s3-us-west-2.amazonaws.com/grafana-releases/release'
   if $::grafana::archive_source != undef {
     $real_archive_source = $::grafana::archive_source
   }
   else {
-    $real_archive_source = "https://grafanarel.s3.amazonaws.com/builds/grafana-${::grafana::version}.linux-x64.tar.gz"
+    $real_archive_source = "${base_url}/grafana-${::grafana::version}.linux-x64.tar.gz"
   }
 
   if $::grafana::package_source != undef {
@@ -13,8 +14,8 @@ class grafana::install {
   }
   else {
     $real_package_source = $::osfamily ? {
-      /(RedHat|Amazon)/ => "https://grafanarel.s3.amazonaws.com/builds/grafana-${::grafana::version}-${::grafana::rpm_iteration}.x86_64.rpm",
-      'Debian'          => "https://grafanarel.s3.amazonaws.com/builds/grafana_${::grafana::version}_amd64.deb",
+      /(RedHat|Amazon)/ => "${base_url}/grafana-${::grafana::version}-${::grafana::rpm_iteration}.x86_64.rpm",
+      'Debian'          => "${base_url}/builds/grafana_${::grafana::version}_amd64.deb",
       default           => $real_archive_source,
     }
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,7 +17,7 @@ class grafana::params {
   $package_source      = undef
   $rpm_iteration       = '1'
   $repo_name           = 'stable'
-  $version             = '2.5.0'
+  $version             = '4.5.1'
   case $::osfamily {
     'Archlinux': {
       $manage_package_repo = false

--- a/metadata.json
+++ b/metadata.json
@@ -9,20 +9,12 @@
   "issue_url": "https://github.com/voxpupuli/puppet-grafana/issues",
   "dependencies": [
     {
-      "name": "garethr/docker",
-      "version_requirement": ">= 5.0.0 < 6.0.0"
-    },
-    {
       "name": "maestrodev/wget",
       "version_requirement": ">= 1.7.3 < 2.0.0"
     },
     {
       "name": "puppet/archive",
       "version_requirement": ">= 1.0.1 < 2.0.0"
-    },
-    {
-      "name": "puppetlabs/apt",
-      "version_requirement": ">=2.1.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
@@ -39,19 +31,22 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.04"
+        "14.04",
+        "16.04"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
+        "6",
         "6"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6"
+        "6",
+        "7"
       ]
     },
     {
@@ -61,7 +56,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.6.1 < 5.0.0"
+      "version_requirement": ">= 4.7.1 < 6.0.0"
     }
   ],
   "tags": [

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -17,7 +17,7 @@ describe 'grafana class' do
       it { is_expected.to be_installed }
     end
 
-    describe service('grafana') do
+    describe service('grafana-server') do
       it { is_expected.to be_enabled }
       it { is_expected.to be_running }
     end

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -28,12 +28,10 @@ describe 'grafana' do
       context 'with default values' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('grafana') }
-        it { is_expected.to contain_anchor('grafana::begin') }
         it { is_expected.to contain_class('grafana::params') }
-        it { is_expected.to contain_class('grafana::install') }
-        it { is_expected.to contain_class('grafana::config') }
+        it { is_expected.to contain_class('grafana::install').that_comes_before('Class[grafana::config]') }
+        it { is_expected.to contain_class('grafana::config').that_notifies('Class[grafana::service]') }
         it { is_expected.to contain_class('grafana::service') }
-        it { is_expected.to contain_anchor('grafana::end') }
       end
 
       context 'with parameter install_method is set to package' do

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -91,7 +91,7 @@ describe 'grafana' do
           end
 
           describe 'install the package' do
-            it { is_expected.to contain_package('grafana').with_ensure('2.5.0') }
+            it { is_expected.to contain_package('grafana').with_ensure('4.5.1') }
           end
         when 'RedHat'
           describe 'yum repo dependencies first' do
@@ -104,7 +104,7 @@ describe 'grafana' do
           end
 
           describe 'install the package' do
-            it { is_expected.to contain_package('grafana').with_ensure('2.5.0-1') }
+            it { is_expected.to contain_package('grafana').with_ensure('4.5.1-1') }
           end
         end
       end
@@ -151,7 +151,7 @@ describe 'grafana' do
 
         install_dir    = '/usr/share/grafana'
         service_config = '/usr/share/grafana/conf/custom.ini'
-        archive_source = 'https://grafanarel.s3.amazonaws.com/builds/grafana-2.5.0.linux-x64.tar.gz'
+        archive_source = 'https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-4.5.1.linux-x64.tar.gz'
 
         describe 'extract archive to install_dir' do
           it { is_expected.to contain_archive('/tmp/grafana.tar.gz').with_ensure('present') }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,24 +1,15 @@
-require 'beaker-rspec/spec_helper'
-require 'beaker-rspec/helpers/serverspec'
+require 'beaker-rspec'
+require 'beaker/puppet_install_helper'
+require 'beaker/module_install_helper'
 
-hosts.each do |_host| # rubocop: disable RSpec/IteratedExpectation
-  # Install Puppet
-  install_puppet
-end
+run_puppet_install_helper
+install_module
+install_module_dependencies
+
+# Install additional modules for soft deps
+install_module_from_forge('puppetlabs-apt', '>= 4.1.0 < 5.0.0')
 
 RSpec.configure do |c|
-  # Project root
-  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-
   # Readable test descriptions
   c.formatter = :documentation
-
-  # Configure all nodes in nodeset
-  c.before :suite do
-    # Install module and dependencies
-    puppet_module_install(source: proj_root, module_name: 'grafana')
-    hosts.each do |host|
-      on host, puppet('module', 'install', 'puppetlabs-stdlib'), acceptable_exit_codes: [0, 1]
-    end
-  end
 end


### PR DESCRIPTION
This PR
- Sets the default Grafana version to 4.5.1. It still leaves the version hard-coded and not set to latest since 2 of the three intallation methods rely on it. The previous configuration did not work on newer systems with default settings.
- Gets rid of anchor pattern and uses `contain()` to declare the classes.
- Sets acceptance tests to run (on CentOS 7 and Ubuntu 16.04) in Travis
- Reworks spec_helper_acceptance
- Adds support for CentOS / RedHat 7, Ubuntu 16.04, and bumps metadata, makes apt and docker  soft dependencies per style guide.

Ran acceptance tests locally for Ubuntu 14.04 and CentOS 6 as well.