### PR TITLE
Get rid of the dependency on 'wget' module in favor of puppet-archive

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,7 +3,6 @@ fixtures:
      stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
      archive: "https://github.com/voxpupuli/puppet-archive.git"
      docker: "https://github.com/garethr/garethr-docker.git"
-     wget: "https://github.com/maestrodev/puppet-wget.git"
      apt: "https://github.com/puppetlabs/puppetlabs-apt.git"
   symlinks:
     grafana: "#{source_dir}"

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -34,16 +34,15 @@ class grafana::install {
             ensure => present,
           }
 
-          wget::fetch { 'grafana':
-            source      => $real_package_source,
-            destination => '/tmp/grafana.deb',
+          archive { '/tmp/grafana.deb':
+            source  => $real_package_source,
           }
 
           package { $::grafana::package_name:
             ensure   => present,
             provider => 'dpkg',
             source   => '/tmp/grafana.deb',
-            require  => [Wget::Fetch['grafana'],Package['libfontconfig1']],
+            require  => [Archive['/tmp/grafana.deb'],Package['libfontconfig1']],
           }
         }
         'RedHat': {

--- a/metadata.json
+++ b/metadata.json
@@ -9,10 +9,6 @@
   "issue_url": "https://github.com/voxpupuli/puppet-grafana/issues",
   "dependencies": [
     {
-      "name": "maestrodev/wget",
-      "version_requirement": ">= 1.7.3 < 2.0.0"
-    },
-    {
       "name": "puppet/archive",
       "version_requirement": ">= 1.0.1 < 2.0.0"
     },

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -45,9 +45,13 @@ describe 'grafana' do
         when 'Debian'
           download_location = '/tmp/grafana.deb'
 
-          describe 'use wget to fetch the package to a temporary location' do
-            it { is_expected.to contain_wget__fetch('grafana').with_destination(download_location) }
-            it { is_expected.to contain_wget__fetch('grafana').that_comes_before('Package[grafana]') }
+          describe 'use archive to fetch the package to a temporary location' do
+            it do
+              is_expected.to contain_archive('/tmp/grafana.deb').with_source(
+                'https://s3-us-west-2.amazonaws.com/grafana-releases/release/builds/grafana_4.5.1_amd64.deb'
+              )
+            end
+            it { is_expected.to contain_archive('/tmp/grafana.deb').that_comes_before('Package[grafana]') }
           end
 
           describe 'install dependencies first' do


### PR DESCRIPTION
Module already has puppet-archive as a dependency, and seems like this is preferable anyway