### PR TITLE
fix typo in metadata (redhat 6 twice vs 6/7)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -35,7 +35,7 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",
-        "6"
+        "7"
       ]
     },
     {


### PR DESCRIPTION
This just fixes a minor typo with RedHat 6 being there twice but 7 not at all.