### PR TITLE
Add support for SLES 11 and 12

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -47,6 +47,13 @@
     },
     {
       "operatingsystem": "Archlinux"
+    },
+    {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "11",
+        "12"
+      ]
     }
   ],
   "requirements": [

--- a/spec/acceptance/nodesets/sles-11-x64.yml
+++ b/spec/acceptance/nodesets/sles-11-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  sles-11-x64:
+    roles:
+      - default
+    platform: sles-11-x64
+    box: suse/sles11sp3
+    box_url: https://vagrantcloud.com/suse/boxes/sles11sp3
+    hypervisor: vagrant
+CONFIG:
+  type: foss

--- a/spec/acceptance/nodesets/sles-12-x64.yml
+++ b/spec/acceptance/nodesets/sles-12-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  sles-12-x64:
+    roles:
+      - default
+    platform: sles-12-x64
+    box: suse/sles12sp1
+    box_url: https://vagrantcloud.com/suse/boxes/sles12sp1
+    hypervisor: vagrant
+CONFIG:
+  type: foss

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -70,6 +70,10 @@ describe 'grafana' do
           describe 'install the package' do
             it { is_expected.to contain_package('grafana').with_provider('rpm') }
           end
+        when 'Suse'
+          describe 'install the package' do
+            it { is_expected.to contain_package('grafana').with_provider('rpm') }
+          end
         end
       end
 


### PR DESCRIPTION
Prior to this PR, SLES was not supported as an installation target.
This commit adds support for SLES using the `package` installation
method. Repo based installation is not provided from grafana, so this PR simply installs the RPM package manually. 

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
