### PR TITLE
Removing the datasource url check as it leads to errors with postgres…

### DIFF
--- a/lib/puppet/type/grafana_datasource.rb
+++ b/lib/puppet/type/grafana_datasource.rb
@@ -30,12 +30,6 @@ Puppet::Type.newtype(:grafana_datasource) do
 
   newproperty(:url) do
     desc 'The URL of the datasource'
-
-    validate do |value|
-      unless value =~ %r{^https?://}
-        raise ArgumentError, format('%s is not a valid URL', value)
-      end
-    end
   end
 
   newproperty(:type) do


### PR DESCRIPTION
…-datasource

The mysql or postgres database has url's which do not start with http or https and there is not record on how the format of the datasource url should look like. Therefore this test needs to be removed in order to being able to add postgres or mysql datasources.
An issue about this matter was created [here](https://github.com/voxpupuli/puppet-grafana/issues/75)
