### PR TITLE
Add grafana_api_path to allow for API sub-paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,20 @@ Example:
 
 ```
 
+
+#### Using a sub-path for Grafana API
+
+If you are using a sub-path for the Grafana API, you will need to set the `grafana_api_path` parameter for the following custom types:
+- `grafana_dashboard`
+- `grafana_datasource`
+- `grafana_organization`
+- `grafana_user`
+
+For instance, if your sub-path is `/grafana`, the `grafana_api_path` must
+be set to `/grafana/api`. Do not add a trailing `/` (slash) at the end of the value.
+
+If you are not using sub-paths, you do not need to set this parameter.
+
 #### Custom Types and Providers
 
 The module includes several custom types:
@@ -367,13 +381,14 @@ grafana_dashboard { 'example_dashboard':
   grafana_url       => 'http://localhost:3000',
   grafana_user      => 'admin',
   grafana_password  => '5ecretPassw0rd',
+  grafana_api_path  => '/grafana/api'
   content           => template('path/to/exported/file.json'),
 }
 ```
 
 `content` must be valid JSON, and is parsed before imported.
 `grafana_user` and `grafana_password` are optional, and required when
-authentication is enabled in Grafana.
+authentication is enabled in Grafana. `grafana_api_path` is optional, and only used when using sub-paths for the API.
 
 Example:
 Make sure the `grafana-server` service is up and running before creating the `grafana_dashboard` definition. One option is to use the `http_conn_validator` from the [healthcheck](https://forge.puppet.com/puppet/healthcheck) module
@@ -403,6 +418,7 @@ grafana_datasource { 'influxdb':
   grafana_url       => 'http://localhost:3000',
   grafana_user      => 'admin',
   grafana_password  => '5ecretPassw0rd',
+  grafana_api_path  => '/grafana/api'
   type              => 'influxdb',
   org_name          => 'NewOrg',
   url               => 'http://localhost:8086',
@@ -424,8 +440,7 @@ from the browser, or `proxy` to send requests via grafana.
 
 Setting `basic_auth` to `true` will allow use of the `basic_auth_user` and `basic_auth_password` params.
 
-Authentication is optional, as is `database`; additional `json_data` can be
-provided to allow custom configuration options.
+Authentication is optional, as are `database` and `grafana_api_path`; additional `json_data` can be provided to allow custom configuration options.
 
 Example:
 Make sure the `grafana-server` service is up and running before creating the `grafana_datasource` definition. One option is to use the `http_conn_validator` from the [healthcheck](https://forge.puppet.com/puppet/healthcheck) module
@@ -561,6 +576,7 @@ Creates and manages a global grafana user via the API.
 ```puppet
 grafana_user { 'username':
   grafana_url       => 'http://localhost:3000',
+  grafana_api_path  => '/grafana/api'
   grafana_user      => 'admin',
   grafana_password  => '5ecretPassw0rd',
   full_name         => 'John Doe',
@@ -568,6 +584,7 @@ grafana_user { 'username':
   email             => 'john@example.com',
 }
 ```
+`grafana_api_path` is only required if using sub-paths for the API
 
 ## Limitations
 

--- a/lib/puppet/provider/grafana_dashboard/grafana.rb
+++ b/lib/puppet/provider/grafana_dashboard/grafana.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
 
   # Return the list of dashboards
   def dashboards
-    response = send_request('GET', '/api/search', nil, q: '', starred: false)
+    response = send_request('GET', format('%s/search', resource[:grafana_api_path]), nil, q: '', starred: false)
     if response.code != '200'
       raise format('Fail to retrieve the dashboards (HTTP response: %s/%s)', response.code, response.body)
     end
@@ -30,7 +30,7 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
   def find_dashboard
     return unless dashboards.find { |x| x['title'] == resource[:title] }
 
-    response = send_request('GET', format('/api/dashboards/db/%s', slug))
+    response = send_request('GET', format('%s/dashboards/db/%s', resource[:grafana_api_path], slug))
     if response.code != '200'
       raise format('Fail to retrieve dashboard %s (HTTP response: %s/%s)', resource[:title], response.code, response.body)
     end
@@ -51,7 +51,7 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
       overwrite: !@dashboard.nil?
     }
 
-    response = send_request('POST', '/api/dashboards/db', data)
+    response = send_request('POST', format('%s/dashboards/db', resource[:grafana_api_path]), data)
     return unless response.code != '200'
     raise format('Fail to save dashboard %s (HTTP response: %s/%s', resource[:name], response.code, response.body)
   end
@@ -73,7 +73,7 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
   end
 
   def destroy
-    response = send_request('DELETE', format('/api/dashboards/db/%s', slug))
+    response = send_request('DELETE', format('%s/dashboards/db/%s', resource[:grafana_api_path], slug))
 
     return unless response.code != '200'
     raise Puppet::Error, format('Failed to delete dashboard %s (HTTP response: %s/%s', resource[:title], response.code, response.body)

--- a/lib/puppet/provider/grafana_datasource/grafana.rb
+++ b/lib/puppet/provider/grafana_datasource/grafana.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:grafana_datasource).provide(:grafana, parent: Puppet::Provide
   end
 
   def fetch_organizations
-    response = send_request('GET', '/api/orgs')
+    response = send_request('GET', format('%s/orgs', resource[:grafana_api_path]))
     if response.code != '200'
       raise format('Fail to retrieve organizations (HTTP response: %s/%s)', response.code, response.body)
     end
@@ -23,7 +23,7 @@ Puppet::Type.type(:grafana_datasource).provide(:grafana, parent: Puppet::Provide
       fetch_organizations = JSON.parse(response.body)
 
       fetch_organizations.map { |x| x['id'] }.map do |id|
-        response = send_request 'GET', format('/api/orgs/%s', id)
+        response = send_request('GET', format('%s/orgs/%s', resource[:grafana_api_path], id))
         if response.code != '200'
           raise format('Failed to retrieve organization %d (HTTP response: %s/%s)', id, response.code, response.body)
         end
@@ -48,7 +48,7 @@ Puppet::Type.type(:grafana_datasource).provide(:grafana, parent: Puppet::Provide
   end
 
   def datasources
-    response = send_request('GET', '/api/datasources')
+    response = send_request('GET', format('%s/datasources', resource[:grafana_api_path]))
     if response.code != '200'
       raise format('Fail to retrieve datasources (HTTP response: %s/%s)', response.code, response.body)
     end
@@ -57,7 +57,7 @@ Puppet::Type.type(:grafana_datasource).provide(:grafana, parent: Puppet::Provide
       datasources = JSON.parse(response.body)
 
       datasources.map { |x| x['id'] }.map do |id|
-        response = send_request 'GET', format('/api/datasources/%s', id)
+        response = send_request('GET', format('%s/datasources/%s', resource[:grafana_api_path], id))
         if response.code != '200'
           raise format('Failed to retrieve datasource %d (HTTP response: %s/%s)', id, response.code, response.body)
         end
@@ -207,13 +207,13 @@ Puppet::Type.type(:grafana_datasource).provide(:grafana, parent: Puppet::Provide
 
   def save_datasource
     if fetch_organization.nil?
-      response = send_request('POST', '/api/user/using/1')
+      response = send_request('POST', format('%s/user/using/1', resource[:grafana_api_path]))
       if response.code != '200'
         raise format('Failed to switch to org 1 (HTTP response: %s/%s)', response.code, response.body)
       end
     else
       organization_id = fetch_organization[:id]
-      response = send_request 'POST', format('/api/user/using/%s', organization_id)
+      response = send_request 'POST', format('%s/user/using/%s', resource[:grafana_api_path], organization_id)
       if response.code != '200'
         raise format('Failed to switch to org %s (HTTP response: %s/%s)', organization_id, response.code, response.body)
       end
@@ -236,10 +236,10 @@ Puppet::Type.type(:grafana_datasource).provide(:grafana, parent: Puppet::Provide
     }
 
     if datasource.nil?
-      response = send_request('POST', '/api/datasources', data)
+      response = send_request('POST', format('%s/datasources', resource[:grafana_api_path]), data)
     else
       data[:id] = datasource[:id]
-      response = send_request 'PUT', format('/api/datasources/%s', datasource[:id]), data
+      response = send_request('PUT', format('%s/datasources/%s', resource[:grafana_api_path], datasource[:id]), data)
     end
 
     if response.code != '200'
@@ -249,7 +249,7 @@ Puppet::Type.type(:grafana_datasource).provide(:grafana, parent: Puppet::Provide
   end
 
   def delete_datasource
-    response = send_request 'DELETE', format('/api/datasources/%s', datasource[:id])
+    response = send_request('DELETE', format('%s/datasources/%s', resource[:grafana_api_path], datasource[:id]))
 
     if response.code != '200'
       raise format('Failed to delete datasource %s (HTTP response: %s/%s', resource[:name], response.code, response.body)

--- a/lib/puppet/provider/grafana_organization/grafana.rb
+++ b/lib/puppet/provider/grafana_organization/grafana.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:grafana_organization).provide(:grafana, parent: Puppet::Provi
   defaultfor kernel: 'Linux'
 
   def organizations
-    response = send_request('GET', '/api/orgs')
+    response = send_request('GET', format('%s/orgs', resource[:grafana_api_path]))
     if response.code != '200'
       raise format('Failed to retrieve organizations (HTTP response: %s/%s)', response.code, response.body)
     end
@@ -17,7 +17,7 @@ Puppet::Type.type(:grafana_organization).provide(:grafana, parent: Puppet::Provi
       organizations = JSON.parse(response.body)
 
       organizations.map { |x| x['id'] }.map do |id|
-        response = send_request 'GET', format('/api/orgs/%s', id)
+        response = send_request 'GET', format('%s/orgs/%s', resource[:grafana_api_path], id)
         if response.code != '200'
           raise format('Failed to retrieve organization %d (HTTP response: %s/%s)', id, response.code, response.body)
         end
@@ -71,7 +71,7 @@ Puppet::Type.type(:grafana_organization).provide(:grafana, parent: Puppet::Provi
       address: resource[:address]
     }
 
-    response = send_request('POST', '/api/orgs', data) if organization.nil?
+    response = send_request('POST', format('%s/orgs', resource[:grafana_api_path]), data) if organization.nil?
 
     if response.code != '200'
       raise format('Failed to create save %s (HTTP response: %s/%s)', resource[:name], response.code, response.body)
@@ -80,7 +80,7 @@ Puppet::Type.type(:grafana_organization).provide(:grafana, parent: Puppet::Provi
   end
 
   def delete_organization
-    response = send_request 'DELETE', format('/api/orgs/%s', organization[:id])
+    response = send_request('DELETE', format('%s/orgs/%s', resource[:grafana_api_path], organization[:id]))
 
     if response.code != '200'
       raise format('Failed to delete organization %s (HTTP response: %s/%s)', resource[:name], response.code, response.body)

--- a/lib/puppet/provider/grafana_user/grafana.rb
+++ b/lib/puppet/provider/grafana_user/grafana.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:grafana_user).provide(:grafana, parent: Puppet::Provider::Gra
   defaultfor kernel: 'Linux'
 
   def users
-    response = send_request('GET', '/api/users')
+    response = send_request('GET', format('%s/users', resource[:grafana_api_path]))
     if response.code != '200'
       raise format('Fail to retrieve users (HTTP response: %s/%s)', response.code, response.body)
     end
@@ -17,7 +17,7 @@ Puppet::Type.type(:grafana_user).provide(:grafana, parent: Puppet::Provider::Gra
       users = JSON.parse(response.body)
 
       users.map { |x| x['id'] }.map do |id|
-        response = send_request 'GET', format('/api/users/%s', id)
+        response = send_request('GET', format('%s/users/%s', resource[:grafana_api_path], id))
         if response.code != '200'
           raise format('Fail to retrieve user %d (HTTP response: %s/%s)', id, response.code, response.body)
         end
@@ -112,12 +112,12 @@ Puppet::Type.type(:grafana_user).provide(:grafana, parent: Puppet::Provider::Gra
     }
 
     if user.nil?
-      response = send_request('POST', '/api/admin/users', data)
+      response = send_request('POST', format('%s/admin/users', resource[:grafana_api_path]), data)
     else
       data[:id] = user[:id]
-      send_request 'PUT', format('/api/admin/users/%s/password', user[:id]), password: data.delete(:password)
-      send_request 'PUT', format('/api/admin/users/%s/permissions', user[:id]), isGrafanaAdmin: data.delete(:isGrafanaAdmin)
-      response = send_request 'PUT', format('/api/users/%s', user[:id]), data
+      send_request 'PUT', format('%s/admin/users/%s/password', resource[:grafana_api_path], user[:id]), password: data.delete(:password)
+      send_request 'PUT', format('%s/admin/users/%s/permissions', resource[:grafana_api_path], user[:id]), isGrafanaAdmin: data.delete(:isGrafanaAdmin)
+      response = send_request('PUT', format('%s/users/%s', resource[:grafana_api_path], user[:id]), data)
     end
 
     if response.code != '200'
@@ -127,7 +127,7 @@ Puppet::Type.type(:grafana_user).provide(:grafana, parent: Puppet::Provider::Gra
   end
 
   def delete_user
-    response = send_request 'DELETE', format('/api/admin/users/%s', user[:id])
+    response = send_request('DELETE', format('%s/admin/users/%s', resource[:grafana_api_path], user[:id]))
 
     if response.code != '200'
       raise format('Failed to delete user %s (HTTP response: %s/%s', resource[:name], response.code, response.body)

--- a/lib/puppet/type/grafana_dashboard.rb
+++ b/lib/puppet/type/grafana_dashboard.rb
@@ -55,6 +55,17 @@ Puppet::Type.newtype(:grafana_dashboard) do
     desc 'The password for the Grafana server (optional)'
   end
 
+  newparam(:grafana_api_path) do
+    desc 'The absolute path to the API endpoint'
+    defaultto '/api'
+
+    validate do |value|
+      unless value =~ %r{^/.*/?api$}
+        raise ArgumentError, format('%s is not a valid API path', value)
+      end
+    end
+  end
+
   # rubocop:disable Style/SignalException
   validate do
     fail('content is required when ensure is present') if self[:ensure] == :present && self[:content].nil?

--- a/lib/puppet/type/grafana_datasource.rb
+++ b/lib/puppet/type/grafana_datasource.rb
@@ -9,6 +9,17 @@ Puppet::Type.newtype(:grafana_datasource) do
     desc 'The name of the datasource.'
   end
 
+  newparam(:grafana_api_path) do
+    desc 'The absolute path to the API endpoint'
+    defaultto '/api'
+
+    validate do |value|
+      unless value =~ %r{^/.*/?api$}
+        raise ArgumentError, format('%s is not a valid API path', value)
+      end
+    end
+  end
+
   newparam(:grafana_url) do
     desc 'The URL of the Grafana server'
     defaultto ''

--- a/lib/puppet/type/grafana_organization.rb
+++ b/lib/puppet/type/grafana_organization.rb
@@ -10,6 +10,17 @@ Puppet::Type.newtype(:grafana_organization) do
     desc 'The name of the organization.'
   end
 
+  newparam(:grafana_api_path) do
+    desc 'The absolute path to the API endpoint'
+    defaultto '/api'
+
+    validate do |value|
+      unless value =~ %r{^/.*/?api$}
+        raise ArgumentError, format('%s is not a valid API path', value)
+      end
+    end
+  end
+
   newparam(:grafana_url) do
     desc 'The URL of the Grafana server'
     defaultto ''

--- a/lib/puppet/type/grafana_user.rb
+++ b/lib/puppet/type/grafana_user.rb
@@ -7,6 +7,17 @@ Puppet::Type.newtype(:grafana_user) do
     desc 'The username of the user.'
   end
 
+  newparam(:grafana_api_path) do
+    desc 'The absolute path to the API endpoint'
+    defaultto '/api'
+
+    validate do |value|
+      unless value =~ %r{^/.*/?api$}
+        raise ArgumentError, format('%s is not a valid API path', value)
+      end
+    end
+  end
+
   newparam(:grafana_url) do
     desc 'The URL of the Grafana server'
     defaultto ''


### PR DESCRIPTION
- Updated types and providers to allow the grafana_api_path parameter to
be set when using sub-paths for the API