### PR TITLE
Add postgres support and secure_json_data support

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,12 +366,12 @@ grafana_organization { 'example_org':
 }
 ```
 
-`grafana_url`, `grafana_user`, and `grafana_password` are required to create organizations via the API. 
+`grafana_url`, `grafana_user`, and `grafana_password` are required to create organizations via the API.
 
 `name` is optional if the name will differ from example_org above.
 
 `address` is an optional parameter that requires a hash. Address settings are `{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}`
-  
+
 #### `grafana_dashboard`
 
 In order to use the dashboard resource, add the following to your manifest:
@@ -416,32 +416,33 @@ In order to use the datasource resource, add the following to your manifest:
 
 ```puppet
 grafana_datasource { 'influxdb':
-  grafana_url       => 'http://localhost:3000',
-  grafana_user      => 'admin',
-  grafana_password  => '5ecretPassw0rd',
-  grafana_api_path  => '/grafana/api',
-  type              => 'influxdb',
-  organization      => 'NewOrg',
-  url               => 'http://localhost:8086',
-  user              => 'admin',
-  password          => '1nFlux5ecret',
-  database          => 'graphite',
-  access_mode       => 'proxy',
-  is_default        => true,
-  json_data         => template('path/to/additional/config.json'),
+  grafana_url      => 'http://localhost:3000',
+  grafana_user     => 'admin',
+  grafana_password => '5ecretPassw0rd',
+  grafana_api_path => '/grafana/api',
+  type             => 'influxdb',
+  organization     => 'NewOrg',
+  url              => 'http://localhost:8086',
+  user             => 'admin',
+  password         => '1nFlux5ecret',
+  database         => 'graphite',
+  access_mode      => 'proxy',
+  is_default       => true,
+  json_data        => template('path/to/additional/config.json'),
+  secure_json_data => template('path/to/additional/secure/config.json')
 }
 ```
 
-Available types are: influxdb, elasticsearch, graphite, cloudwatch, mysql, opentsdb, and prometheus
+Available types are: influxdb, elasticsearch, graphite, cloudwatch, mysql, opentsdb, postgres and prometheus
 
-`organization` is used to set which organization a datasource will be created on. If this parameter is not set, it will default to organization ID 1 (Main Org. by default). If the default org is deleted, organizations will need to be specified. 
+`organization` is used to set which organization a datasource will be created on. If this parameter is not set, it will default to organization ID 1 (Main Org. by default). If the default org is deleted, organizations will need to be specified.
 
 Access mode determines how Grafana connects to the datasource, either `direct`
 from the browser, or `proxy` to send requests via grafana.
 
 Setting `basic_auth` to `true` will allow use of the `basic_auth_user` and `basic_auth_password` params.
 
-Authentication is optional, as are `database` and `grafana_api_path`; additional `json_data` can be provided to allow custom configuration options.
+Authentication is optional, as are `database` and `grafana_api_path`; additional `json_data` and `secure_json_data` can be provided to allow custom configuration options.
 
 Example:
 Make sure the `grafana-server` service is up and running before creating the `grafana_datasource` definition. One option is to use the `http_conn_validator` from the [healthcheck](https://forge.puppet.com/puppet/healthcheck) module
@@ -473,7 +474,7 @@ Note that the `database` is dynamic, setting things other than "database" for se
 
 **`jsonData` Settings**
 
-Note that there are separate options for json_data based on the type of datasource you create.
+Note that there are separate options for json_data / secure_json_data based on the type of datasource you create.
 
 ##### **Elasticsearch**
 
@@ -491,16 +492,16 @@ json_data => {"esVersion":5,"timeField":"@timestamp","timeInterval":"1m"}
 ##### **CloudWatch**
 
 `authType` - Required. Options are `Access & Secret Key`, `Credentials File`, or `ARN`.
-  
+
 -"keys" = Access & Secret Key
 
 -"credentials" = Credentials File
 
 -"arn" = ARN
- 
+
 *When setting authType to `credentials`, the `database` param will set the Credentials Profile Name.*
 
-*When setting authType to `arn`, another jsonData value of `assumeRoleARN` is available, which is not required for other authType settings*     
+*When setting authType to `arn`, another jsonData value of `assumeRoleARN` is available, which is not required for other authType settings*
 
 `customMetricsNamespaces` - Optional. Namespaces of Custom Metrics, separated by commas within double quotes.
 
@@ -508,11 +509,11 @@ json_data => {"esVersion":5,"timeField":"@timestamp","timeInterval":"1m"}
 
 `timeField`
 
-Example: 
+Example:
 ```puppet
 {"authType":"arn","assumeRoleARN":"arn:aws:iam:*","customMetricsNamespaces":"Namespace1,Namespace2","defaultRegion":"us-east-1","timeField":"@timestamp"}
 ```
-     
+
 ##### **Graphite**
 
 `graphiteVersion` - Required. Available versions are `0.9` or `1.0`.

--- a/lib/puppet/provider/grafana_datasource/grafana.rb
+++ b/lib/puppet/provider/grafana_datasource/grafana.rb
@@ -85,7 +85,8 @@ Puppet::Type.type(:grafana_datasource).provide(:grafana, parent: Puppet::Provide
           basic_auth: datasource['basicAuth'] ? :true : :false,
           basic_auth_user: datasource['basicAuthUser'],
           basic_auth_password: datasource['basicAuthPassword'],
-          json_data: datasource['jsonData']
+          json_data: datasource['jsonData'],
+          secure_json_data: datasource['secureJsonData']
         }
       end
     rescue JSON::ParserError
@@ -212,6 +213,15 @@ Puppet::Type.type(:grafana_datasource).provide(:grafana, parent: Puppet::Provide
     save_datasource
   end
 
+  def secure_json_data
+    datasource[:secure_json_data]
+  end
+
+  def secure_json_data=(value)
+    resource[:secure_json_data] = value
+    save_datasource
+  end
+
   def save_datasource
     # change organizations
     response = send_request 'POST', format('%s/user/using/%s', resource[:grafana_api_path], fetch_organization[:id])
@@ -232,7 +242,8 @@ Puppet::Type.type(:grafana_datasource).provide(:grafana, parent: Puppet::Provide
       basicAuthUser: resource[:basic_auth_user],
       basicAuthPassword: resource[:basic_auth_password],
       withCredentials: (resource[:with_credentials] == :true),
-      jsonData: resource[:json_data]
+      jsonData: resource[:json_data],
+      secureJsonData: resource[:secure_json_data]
     }
 
     if datasource.nil?

--- a/lib/puppet/type/grafana_datasource.rb
+++ b/lib/puppet/type/grafana_datasource.rb
@@ -40,13 +40,7 @@ Puppet::Type.newtype(:grafana_datasource) do
   end
 
   newproperty(:url) do
-    desc 'The URL of the datasource'
-
-    validate do |value|
-      unless value =~ %r{^https?://}
-        raise ArgumentError, format('%s is not a valid URL', value)
-      end
-    end
+    desc 'The URL/Endpoint of the datasource'
   end
 
   newproperty(:type) do

--- a/lib/puppet/type/grafana_datasource.rb
+++ b/lib/puppet/type/grafana_datasource.rb
@@ -51,7 +51,7 @@ Puppet::Type.newtype(:grafana_datasource) do
 
   newproperty(:type) do
     desc 'The datasource type'
-    newvalues(:influxdb, :elasticsearch, :graphite, :kairosdb, :opentsdb, :prometheus)
+    newvalues(:influxdb, :elasticsearch, :graphite, :kairosdb, :opentsdb, :prometheus, :postgres)
   end
 
   newparam(:organization) do

--- a/lib/puppet/type/grafana_datasource.rb
+++ b/lib/puppet/type/grafana_datasource.rb
@@ -115,6 +115,16 @@ Puppet::Type.newtype(:grafana_datasource) do
     end
   end
 
+  newproperty(:secure_json_data) do
+    desc 'Additional secure JSON data to configure the datasource (optional)'
+
+    validate do |value|
+      unless value.nil? || value.is_a?(Hash)
+        raise ArgumentError, 'secure_json_data should be a Hash!'
+      end
+    end
+  end
+
   autorequire(:service) do
     'grafana-server'
   end

--- a/spec/unit/puppet/type/grafana_datasource_type_spec.rb
+++ b/spec/unit/puppet/type/grafana_datasource_type_spec.rb
@@ -30,7 +30,8 @@ describe Puppet::Type.type(:grafana_datasource) do
       database: 'test_db',
       user: 'db_user',
       password: 'db_password',
-      json_data: { esVersion: 5, timeField: '@timestamp', timeInterval: '1m' }
+      json_data: { esVersion: 5, timeField: '@timestamp', timeInterval: '1m' },
+      secure_json_data: { password: '5ecretPassw0rd' }
     )
   end
 
@@ -52,6 +53,12 @@ describe Puppet::Type.type(:grafana_datasource) do
         described_class.new name: 'foo', grafana_url: 'http://example.com', json_data: 'invalid', ensure: :present
       end.to raise_error(Puppet::Error, %r{json_data should be a Hash})
     end
+
+    it "fails if secure_json_data isn't valid" do
+      expect do
+        described_class.new name: 'foo', grafana_url: 'http://example.com', secure_json_data: 'invalid', ensure: :present
+      end.to raise_error(Puppet::Error, %r{json_data should be a Hash})
+    end
     # rubocop:disable RSpec/MultipleExpectations
     it 'accepts valid parameters' do
       expect(gdatasource[:name]).to eq('foo')
@@ -69,6 +76,7 @@ describe Puppet::Type.type(:grafana_datasource) do
       expect(gdatasource[:user]).to eq('db_user')
       expect(gdatasource[:password]).to eq('db_password')
       expect(gdatasource[:json_data]).to eq(esVersion: 5, timeField: '@timestamp', timeInterval: '1m')
+      expect(gdatasource[:secure_json_data]).to eq(password: '5ecretPassw0rd')
     end
     # rubocop:enable RSpec/MultipleExpectations
 

--- a/spec/unit/puppet/type/grafana_datasource_type_spec.rb
+++ b/spec/unit/puppet/type/grafana_datasource_type_spec.rb
@@ -42,12 +42,6 @@ describe Puppet::Type.type(:grafana_datasource) do
       end.to raise_error(Puppet::Error, %r{not a valid URL})
     end
 
-    it "fails if url isn't HTTP-based" do
-      expect do
-        described_class.new name: 'foo', url: 'example.com', content: '{}', ensure: :present
-      end.to raise_error(Puppet::Error, %r{not a valid URL})
-    end
-
     it "fails if json_data isn't valid" do
       expect do
         described_class.new name: 'foo', grafana_url: 'http://example.com', json_data: 'invalid', ensure: :present


### PR DESCRIPTION
In order to support postgresql as datasource type I add support for specifying secure_json_data (which is needed when you setup a postgres datasource).

I removed the https datasource url-check again as it breaks the datasource check when postgres is used. ( fyi https://github.com/voxpupuli/puppet-grafana/pull/76)