### PR TITLE
Update release codename from jessie to stretch.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -75,7 +75,7 @@ class grafana::install {
             }
             apt::source { 'grafana':
               location => "https://packagecloud.io/grafana/${::grafana::repo_name}/debian",
-              release  => 'jessie',
+              release  => 'stretch',
               repos    => 'main',
               key      =>  {
                 'id'     => '418A7F2FB0E1E6E7EABF6FE8C2E73424D59097AB',

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -99,7 +99,7 @@ describe 'grafana' do
         when 'Debian'
           describe 'install apt repo dependencies first' do
             it { is_expected.to contain_class('apt') }
-            it { is_expected.to contain_apt__source('grafana').with(release: 'jessie', repos: 'main', location: 'https://packagecloud.io/grafana/stable/debian') }
+            it { is_expected.to contain_apt__source('grafana').with(release: 'stretch', repos: 'main', location: 'https://packagecloud.io/grafana/stable/debian') }
             it { is_expected.to contain_apt__source('grafana').that_comes_before('Package[grafana]') }
           end
 


### PR DESCRIPTION
Grafana upstream documetation: http://docs.grafana.org/installation/debian/, says to use 'stretch' codename for all repositories.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Update release codename from jessie to stretch, as per instructions at http://docs.grafana.org/installation/debian/.

N.B. This PR was tested on my own system, Debian 9 stretch. Could someone please check to see if older and other Ubuntu distributions will be affected by this change?

#### This Pull Request (PR) fixes the following issues
Fixes #112 