### PR TITLE
to_h missing method workaround for ruby2.0 and younger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ script:
 matrix:
   fast_finish: true
   include:
+  - rvm: 1.9.3
+    bundler_args: --without system_tests development release
+    env: PUPPET_VERSION="~> 4.0" CHECK=test
   - rvm: 2.1.9
     bundler_args: --without system_tests development release
     env: PUPPET_VERSION="~> 4.0" CHECK=test PARALLEL_TEST_PROCESSORS=12

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   include:
   - rvm: 1.9.3
     bundler_args: --without system_tests development release
-    env: PUPPET_VERSION="~> 4.0" CHECK=test BEAKER_VERSION="~> 2.50" 
+    env: PUPPET_VERSION="~> 4.0" CHECK=test BEAKER_VERSION="~> 2.50"
   - rvm: 2.1.9
     bundler_args: --without system_tests development release
     env: PUPPET_VERSION="~> 4.0" CHECK=test PARALLEL_TEST_PROCESSORS=12

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   include:
   - rvm: 1.9.3
     bundler_args: --without system_tests development release
-    env: PUPPET_VERSION="~> 4.0" CHECK=test BEAKER_VERSION="~> 2.50" OVERCOMMIT_VERSION="~> 0.30.0"
+    env: PUPPET_VERSION="~> 4.0" CHECK=test BEAKER_VERSION="~> 2.50" BEAKER_RSPEC_VERSION="~> 5.6.0"
   - rvm: 2.1.9
     bundler_args: --without system_tests development release
     env: PUPPET_VERSION="~> 4.0" CHECK=test PARALLEL_TEST_PROCESSORS=12

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   include:
   - rvm: 1.9.3
     bundler_args: --without system_tests development release
-    env: PUPPET_VERSION="~> 4.0" CHECK=test BEAKER_VERSION="~> 2.50"
+    env: PUPPET_VERSION="~> 4.0" CHECK=test BEAKER_VERSION="~> 2.50" OVERCOMMIT_VERSION="~> 0.30.0"
   - rvm: 2.1.9
     bundler_args: --without system_tests development release
     env: PUPPET_VERSION="~> 4.0" CHECK=test PARALLEL_TEST_PROCESSORS=12

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   include:
   - rvm: 1.9.3
     bundler_args: --without system_tests development release
-    env: PUPPET_VERSION="~> 4.0" CHECK=test BEAKER_VERSION="~> 2.50" BEAKER_RSPEC_VERSION="~> 5.6.0"
+    env: PUPPET_VERSION="~> 4.0" CHECK=test BEAKER_VERSION="~> 2.50" 
   - rvm: 2.1.9
     bundler_args: --without system_tests development release
     env: PUPPET_VERSION="~> 4.0" CHECK=test PARALLEL_TEST_PROCESSORS=12

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   include:
   - rvm: 1.9.3
     bundler_args: --without system_tests development release
-    env: PUPPET_VERSION="~> 4.0" CHECK=test
+    env: PUPPET_VERSION="~> 4.0" CHECK=test BEAKER_VERSION="~> 2.50"
   - rvm: 2.1.9
     bundler_args: --without system_tests development release
     env: PUPPET_VERSION="~> 4.0" CHECK=test PARALLEL_TEST_PROCESSORS=12

--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,11 @@ end
 
 group :release do
   gem 'github_changelog_generator',  :require => false, :git => 'https://github.com/skywinder/github-changelog-generator' if RUBY_VERSION >= '2.2.2'
-  gem 'puppet-blacksmith',           :require => false
+  if RUBY_VERSION < '2.0.0'
+    gem 'puppet-blacksmith', '~> 4.0.0',            :require => false
+  else
+    gem 'puppet-blacksmith',           :require => false
+  end
   gem 'voxpupuli-release',           :require => false, :git => 'https://github.com/voxpupuli/voxpupuli-release-gem'
   gem 'puppet-strings', '>= 1.0',    :require => false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,11 @@ group :development do
   gem 'travis',                   :require => false
   gem 'travis-lint',              :require => false
   gem 'guard-rake',               :require => false
-  gem 'overcommit', '>= 0.39.1',  :require => false
+  if overcommit_version = ENV['OVERCOMMIT_VERSION']
+    gem 'overcommit', *location_for(overcommit_version)
+  else
+    gem 'overcommit', '>= 0.39.1',  :require => false 
+  end
 end
 
 group :system_tests do

--- a/Gemfile
+++ b/Gemfile
@@ -14,30 +14,41 @@ group :test do
   gem 'puppetlabs_spec_helper', '~> 2.6',                           :require => false
   gem 'rspec-puppet', '~> 2.5',                                     :require => false
   gem 'rspec-puppet-facts',                                         :require => false
-  gem 'rspec-puppet-utils',                                         :require => false
+  gem 'rspec-puppet-utils',                                         :require => false if RUBY_VERSION >= '2.0.0'
   gem 'puppet-lint-leading_zero-check',                             :require => false
   gem 'puppet-lint-trailing_comma-check',                           :require => false
   gem 'puppet-lint-version_comparison-check',                       :require => false
   gem 'puppet-lint-classes_and_types_beginning_with_digits-check',  :require => false
   gem 'puppet-lint-unquoted_string-check',                          :require => false
   gem 'puppet-lint-variable_contains_upcase',                       :require => false
-  gem 'metadata-json-lint',                                         :require => false
+  gem 'metadata-json-lint',                                         :require => false if RUBY_VERSION >= '2.0.0'
   gem 'redcarpet',                                                  :require => false
   gem 'rubocop', '~> 0.49.1',                                       :require => false if RUBY_VERSION >= '2.3.0'
   gem 'rubocop-rspec', '~> 1.15.0',                                 :require => false if RUBY_VERSION >= '2.3.0'
   gem 'mocha', '~> 1.4.0',                                          :require => false
+  if RUBY_VERSION < '2.0.0'
+    gem 'metadata-json-lint', '~> 0.0.11',                          :require => false
+    gem 'tins', '~> 1.6.0',                                         :require => false
+    gem 'term-ansicolor', '~> 1.3.2',                               :require => false
+    gem 'parallel_tests', '~> 2.9.0',                               :require => false
+    gem 'rspec-puppet-utils', '~> 2.2.1',                           :require => false 
+  end
   gem 'coveralls',                                                  :require => false
   gem 'simplecov-console',                                          :require => false
   gem 'rack', '~> 1.0',                                             :require => false if RUBY_VERSION < '2.2.2'
-  gem 'parallel_tests',                                             :require => false
+  gem 'parallel_tests',                                             :require => false if RUBY_VERSION > '1.9.3'
   gem 'toml',                                                       :require => false
-if RUBY_VERSION > '1.9.3'
-  gem 'overcommit', '>= 0.39.1',                                    :require => false
+  gem 'overcommit', '>= 0.39.1',                                    :require => false if RUBY_VERSION > '1.9.3'
 end
 
 group :development do
   gem 'travis',                   :require => false
   gem 'travis-lint',              :require => false
+  if rake_version = ENV['RAKE_VERSION']
+    gem 'rake', *location_for(rake_version)
+  else
+    gem 'rake',                   :require => false
+  end
   gem 'guard-rake',               :require => false
 end
 
@@ -48,10 +59,10 @@ group :system_tests do
   else
     gem 'beaker', '>= 3.9.0', :require => false
   end
-  if beaker_rspec_version = ENV['BEAKER_RSPEC_VERSION']
-    gem 'beaker-rspec', *location_for(beaker_rspec_version)
+  if RUBY_VERSION < '2.0.0'
+    gem 'beaker-rspec', '~> 5.6.0',              :require => false
   else
-    gem 'beaker-rspec',  :require => false
+    gem 'beaker-rspec',                          :require => false
   end
   gem 'serverspec',                         :require => false
   gem 'beaker-hostgenerator', '>= 1.1.10',  :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -31,17 +31,14 @@ group :test do
   gem 'rack', '~> 1.0',                                             :require => false if RUBY_VERSION < '2.2.2'
   gem 'parallel_tests',                                             :require => false
   gem 'toml',                                                       :require => false
+if RUBY_VERSION > '1.9.3'
+  gem 'overcommit', '>= 0.39.1',                                    :require => false
 end
 
 group :development do
   gem 'travis',                   :require => false
   gem 'travis-lint',              :require => false
   gem 'guard-rake',               :require => false
-  if overcommit_version = ENV['OVERCOMMIT_VERSION']
-    gem 'overcommit', *location_for(overcommit_version)
-  else
-    gem 'overcommit', '>= 0.39.1',  :require => false 
-  end
 end
 
 group :system_tests do

--- a/Gemfile
+++ b/Gemfile
@@ -77,12 +77,7 @@ end
 
 group :release do
   gem 'github_changelog_generator',  :require => false, :git => 'https://github.com/skywinder/github-changelog-generator' if RUBY_VERSION >= '2.2.2'
-  if RUBY_VERSION < '2.0.0'
-    gem 'puppet-blacksmith', '~> 4.0.0',            :require => false
-  else
-    gem 'puppet-blacksmith',           :require => false
-  end
-  gem 'voxpupuli-release',           :require => false, :git => 'https://github.com/voxpupuli/voxpupuli-release-gem'
+  gem 'voxpupuli-release',           :require => false, :git => 'https://github.com/voxpupuli/voxpupuli-release-gem' if RUBY_VERSION >= '1.9.3'
   gem 'puppet-strings', '>= 1.0',    :require => false
 end
 

--- a/lib/puppet/type/grafana_dashboard.rb
+++ b/lib/puppet/type/grafana_dashboard.rb
@@ -24,7 +24,15 @@ Puppet::Type.newtype(:grafana_dashboard) do
 
     munge do |value|
       new_value = JSON.parse(value).reject { |k, _| k =~ %r{^id|version|title$} }
-      new_value.sort.to_h
+      sorted_new_value = new_value.sort
+      
+      # This is a fix for the missing to_h method introduced in Ruby 2.1.0
+      # https://stackoverflow.com/a/9571767
+      if sorted_new_value.respond_to?('to_h')
+        sorted_new_value.to_h
+      else
+        Hash[sorted_new_value.map {|key, value| [key, value]}]
+      end
     end
 
     def should_to_s(value)


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Due to technical debt, we were not able to implement `puppet-grafana`. Thankfully, we're on a roadmap to bring our modules up to date - however as it stands currently, we're running our modules on Ruby `1.9.3-p551` (note: before forcing rightful shame on me, this was the case before I began working on these modules 😉)

This PR addresses the lack of a `to_h` method in the runtime, and instead utilizes a work around to map an Array to a hash - much in the same way that the `to_h` method would. This is also a safe handler for checking whether or not `to_h` method exists - this way munging will use the `to_h` method if available and if not, it will dissect the array and manually create a new Hash.

#### This Pull Request (PR) fixes the following issues
- Inability to utilize `puppet-grafana` in environments running pre-Ruby 2.x