### PR TITLE
add --repo option to grafana_cli plugin install

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,15 @@ grafana_plugin { 'grafana-simple-json-datasource':
 }
 ```
 
+It is possible to specify a custom plugin repository to install a plugin. This will use the --repo option for plugin installation with grafana_cli. 
+
+```puppet
+grafana_plugin { 'grafana-simple-json-datasource':
+  ensure    => present,
+  repo => 'https://nexus.company.com/grafana/plugins',
+}
+```
+
 ##### `grafana::user`
 
 Creates and manages a global grafana user via the API.

--- a/lib/puppet/provider/grafana_plugin/grafana_cli.rb
+++ b/lib/puppet/provider/grafana_plugin/grafana_cli.rb
@@ -45,7 +45,12 @@ Puppet::Type.type(:grafana_plugin).provide(:grafana_cli) do
   end
 
   def create
-    grafana_cli('plugins', 'install', resource[:name])
+    if resource[:repo]
+      repo = "--repo #{resource[:repo]}"
+      grafana_cli(repo, 'plugins', 'install', resource[:name])
+    else
+      grafana_cli('plugins', 'install', resource[:name])
+    end
     @property_hash[:ensure] = :present
   end
 

--- a/lib/puppet/type/grafana_plugin.rb
+++ b/lib/puppet/type/grafana_plugin.rb
@@ -5,6 +5,12 @@ manages grafana plugins
 @example Install a grafana plugin
  grafana_plugin { 'grafana-simple-json-datasource': }
 
+@example Install a grafana plugin from different repo
+ grafana_plugin { 'grafana-simple-json-datasource':
+   ensure => present,
+   repo   => 'https://nexus.company.com/grafana/plugins',
+ }
+
 @example Uninstall a grafana plugin
  grafana_plugin { 'grafana-simple-json-datasource':
    ensure => absent,
@@ -27,5 +33,15 @@ DESC
   newparam(:name, namevar: true) do
     desc 'The name of the plugin to enable'
     newvalues(%r{^\S+$})
+  end
+
+  newparam(:repo) do
+    desc 'The URL of an internal plugin server'
+
+    validate do |value|
+      unless value =~ %r{^https?://}
+        raise ArgumentError, format('%s is not a valid URL', value)
+      end
+    end
   end
 end

--- a/spec/acceptance/grafana_plugin_spec.rb
+++ b/spec/acceptance/grafana_plugin_spec.rb
@@ -17,6 +17,27 @@ describe 'grafana_plugin' do
       end
     end
   end
+
+  context 'create plugin resource with repo' do
+    it 'runs successfully' do
+      pp = <<-EOS
+      class { 'grafana':}
+      grafana_plugin { 'grafana-simple-json-datasource':
+        ensure => present,
+        repo   => 'https://nexus.company.com/grafana/plugins',
+      }
+      EOS
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    it 'has the plugin' do
+      shell('grafana-cli plugins ls') do |r|
+        expect(r.stdout).to match(%r{grafana-simple-json-datasource})
+      end
+    end
+  end
+
   context 'destroy plugin resource' do
     it 'runs successfully' do
       pp = <<-EOS

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -79,13 +79,18 @@ describe 'grafana' do
             plugins:
             {
               'grafana-wizzle' => { 'ensure' => 'present' },
-              'grafana-woozle' => { 'ensure' => 'absent' }
+              'grafana-woozle' => { 'ensure' => 'absent' },
+              'grafana-plugin' => { 'ensure' => 'present', 'repo' => 'https://nexus.company.com/grafana/plugins' }
             }
           }
         end
 
         it { is_expected.to contain_grafana_plugin('grafana-wizzle').with(ensure: 'present') }
         it { is_expected.to contain_grafana_plugin('grafana-woozle').with(ensure: 'absent').that_notifies('Class[grafana::service]') }
+
+        describe 'install plugin with pluginurl' do
+          it { is_expected.to contain_grafana_plugin('grafana-plugin').with(ensure: 'present', repo: 'https://nexus.company.com/grafana/plugins') }
+        end
       end
 
       context 'with parameter install_method is set to repo' do

--- a/spec/unit/puppet/provider/grafana_plugin/grafana_cli_spec.rb
+++ b/spec/unit/puppet/provider/grafana_plugin/grafana_cli_spec.rb
@@ -50,4 +50,18 @@ EOT
     provider.expects(:grafana_cli).with('plugins', 'uninstall', 'grafana-wizzle')
     provider.destroy
   end
+
+  describe 'create with repo' do
+    let(:resource) do
+      Puppet::Type::Grafana_plugin.new(
+        name: 'grafana-plugin',
+        repo: 'https://nexus.company.com/grafana/plugins'
+      )
+    end
+
+    it '#create with repo' do
+      provider.expects(:grafana_cli).with('--repo https://nexus.company.com/grafana/plugins', 'plugins', 'install', 'grafana-plugin')
+      provider.create
+    end
+  end
 end

--- a/spec/unit/puppet/type/grafana_plugin_spec.rb
+++ b/spec/unit/puppet/type/grafana_plugin_spec.rb
@@ -13,4 +13,9 @@ describe Puppet::Type.type(:grafana_plugin) do
       Puppet::Type.type(:grafana_plugin).new({})
     end.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
+
+  it 'accepts a plugin repo' do
+    plugin[:repo] = 'https://nexus.company.com/grafana/plugins'
+    expect(plugin[:repo]).to eq('https://nexus.company.com/grafana/plugins')
+  end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
Adding the repo option to the grafana_cli plugin installation, so that it's possible to use a different repository e.g. a company internal server to install grafana plugins. As an example:

```puppet
grafana_plugin { 'grafana-simple-json-datasource':
  ensure    => present,
  repo => 'https://nexus.company.com/grafana/plugins',
}
```

#### This Pull Request (PR) fixes the following issues
n/a.