### PR TITLE
removing value restriction on grafana_datasource so any custom plugin can be used

### DIFF
--- a/lib/puppet/type/grafana_datasource.rb
+++ b/lib/puppet/type/grafana_datasource.rb
@@ -45,7 +45,6 @@ Puppet::Type.newtype(:grafana_datasource) do
 
   newproperty(:type) do
     desc 'The datasource type'
-    newvalues(:influxdb, :elasticsearch, :graphite, :kairosdb, :opentsdb, :prometheus, :postgres)
   end
 
   newparam(:organization) do

--- a/spec/unit/puppet/type/grafana_datasource_type_spec.rb
+++ b/spec/unit/puppet/type/grafana_datasource_type_spec.rb
@@ -58,7 +58,7 @@ describe Puppet::Type.type(:grafana_datasource) do
       expect(gdatasource[:name]).to eq('foo')
       expect(gdatasource[:grafana_url]).to eq('http://example.com')
       expect(gdatasource[:url]).to eq('http://es.example.com')
-      expect(gdatasource[:type]).to eq(:elasticsearch)
+      expect(gdatasource[:type]).to eq('elasticsearch')
       expect(gdatasource[:organization]).to eq('test_org')
       expect(gdatasource[:access_mode]).to eq(:proxy)
       expect(gdatasource[:is_default]).to eq(:true)


### PR DESCRIPTION
## Affected Puppet, Ruby, OS and module versions/distributions

- Puppet: 5
- Ruby: 2.4
- Distribution: CentOS
- Module version: master

## How to reproduce (e.g Puppet code you use)

```
grafana_datasource { 'PNP':
  type             => 'sni-pnp-datasource',
...
}
```
## What are you seeing

```
Error: Failed to apply catalog: Parameter type failed on Grafana_datasource[PNP]: Invalid value "sni-pnp-datasource". Valid values are influxdb, elasticsearch, graphite, kairosdb, opentsdb, prometheus.
```

## What behaviour did you expect instead

I have a custom Grafana plugin called 'sni-pnp-datasource' loaded into Grafana.  I'm thinking that specifying valid values of only the default plugins is too limiting, and proposing it be removed.