### PR TITLE
Integration notification channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,6 +656,100 @@ grafana_user { 'username':
 ```
 `grafana_api_path` is only required if using sub-paths for the API
 
+##### `grafana::notification`
+
+Creates and manages a global alert notification channel via the API.
+
+```puppet
+grafana_notification { 'channelname':
+  grafana_url       => 'http://localhost:3000',
+  grafana_api_path  => '/grafana/api',
+  grafana_user      => 'admin',
+  grafana_password  => '5ecretPassw0rd',
+
+  name              => 'channelname',
+  type              => 'email',
+  is_default        => false,
+  send_reminder     => false,  
+  frequency         => '20m',
+  settings          => {
+              addresses    => "alerts@example.com; it@example.com"   
+  }
+}
+```
+`grafana_api_path` is only required if using sub-paths for the API 
+
+Notification types and related settingsi (cf doc Grafana : https://github.com/grafana/grafana/blob/master/docs/sources/alerting/notifications.md ) :
+   - email:
+       - addresses: "example.com"
+   - hipchat:
+       - apikey       : "0a0a0a0a0a0a0a0a0a0a0a"
+       - autoResolve  : true
+       - httpMethod   : "POST"
+       - uploadImage  : true
+       - url          : "https://grafana.hipchat.com"
+   - kafka:
+       - autoResolve   : true
+       - httpMethod    : "POST"
+       - kafkaRestProxy: "http://localhost:8082"
+       - kafkaTopic    : "topic1"
+       - uploadImage   : true
+   - LINE:
+       - autoResolve: true
+       - httpMethod : "POST"
+       - token      : "token"
+       - uploadImage: true
+   - teams (Microsoft Teams):
+       - autoResolve : true
+       - httpMethod  : "POST" 
+       - uploadImage :true
+       - url         : "http://example.com"
+   - pagerduty:
+       - autoResolve    : true
+       - httpMethod     : POST
+       - integrationKey :"0a0a0a0a0a"
+       - uploadImage    : true
+   - prometheus-alertmanager:
+       - autoResolve : true
+       - httpMethod  : "POST"
+       - uploadImage : true
+       - url         : "http://localhost:9093"
+   - sensu:
+       - autoResolve : true
+       - handler     : "default",
+       - httpMethod  : "POST"
+       - uploadImage : true
+       - url         : "http://sensu-api.local:4567/results"
+   - slack:
+       - autoResolve : true
+       - httpMethod  : "POST"
+       - uploadImage : true 
+       - url         : "http://slack.com/"
+       - token       : "0a0a0a0a0a0a0a0a0a0a0a"
+   - threema:
+       - api_secret  : "0a0a0a0a0a0a0a0a0a0a0a"
+       - autoResolve : true
+       - gateway_id  : "*3MAGWID"
+       - httpMethod  : "POST"
+       - recipient_id: "YOUR3MID"
+       - uploadImage : true
+   - discord:
+       - autoResolve : true,
+       - httpMethod  : "POST"
+       - uploadImage : true
+       - url         : "https://example.com"
+   - webhook:
+       - autoResolve : true
+       - httpMethod  : "POST"
+       - uploadImage : false
+       - url         : "http://localhost:8080"
+   - telegram:
+       - autoResolve : true
+       - bottoken    : "0a0a0a0a0a0a"
+       - chatid      : "789789789"
+       - httpMethod  : "POST"
+       - uploadImage : true 
+
 #### Provisioning Grafana
 
 [Grafana documentation on

--- a/lib/puppet/provider/grafana_notification/grafana.rb
+++ b/lib/puppet/provider/grafana_notification/grafana.rb
@@ -1,0 +1,146 @@
+#    Copyright 2015 Mirantis, Inc.
+#
+require 'json'
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'grafana'))
+
+Puppet::Type.type(:grafana_notification).provide(:grafana, parent: Puppet::Provider::Grafana) do
+  desc 'Support for Grafana notifications'
+
+  defaultfor kernel: 'Linux'
+
+  def grafana_api_path
+    resource[:grafana_api_path]
+  end
+
+  def notifications
+    response = send_request('GET', format('%s/alert-notifications', resource[:grafana_api_path]))
+    if response.code != '200'
+      raise format('Fail to retrieve notifications (HTTP response: %s/%s)', response.code, response.body)
+    end
+
+    begin
+      notifications = JSON.parse(response.body)
+
+      notifications.map { |x| x['id'] }.map do |id|
+        response = send_request 'GET', format('%s/alert-notifications/%s', resource[:grafana_api_path], id)
+        if response.code != '200'
+          raise format('Failed to retrieve notification %d (HTTP response: %s/%s)', id, response.code, response.body)
+        end
+
+        notification = JSON.parse(response.body)
+
+        {
+          id: notification['id'],
+          name: notification['name'],
+          type: notification['type'],
+          is_default: notification['isDefault'] ? :true : :false,
+          send_reminder: notification['sendReminder'] ? :true : :false,
+          frequency: notification['frequency'],
+          settings: notification['settings']
+        }
+      end
+    rescue JSON::ParserError
+      raise format('Failed to parse response: %s', response.body)
+    end
+  end
+
+  def notification
+    unless @notification
+      @notification = notifications.find { |x| x[:name] == resource[:name] }
+    end
+    @notification
+  end
+
+  attr_writer :notification
+
+  def type
+    notification[:type]
+  end
+
+  def type=(value)
+    resource[:type] = value
+    save_notification
+  end
+
+  # rubocop:disable Style/PredicateName
+  def is_default
+    notification[:is_default]
+  end
+
+  def is_default=(value)
+    resource[:is_default] = value
+    save_notification
+  end
+
+  def send_reminder
+    notification[:send_reminder]
+  end
+
+  def send_reminder=(value)
+    resource[:send_reminder] = value
+    save_notification
+  end
+  # rubocop:enable Style/PredicateName
+
+  def frequency
+    notification[:frequency]
+  end
+
+  def frequency=(value)
+    resource[:frequency] = value
+    save_notification
+  end
+
+  def settings
+    notification[:settings]
+  end
+
+  def settings=(value)
+    resource[:settings] = value
+    save_notification
+  end
+
+  def save_notification
+    data = {
+      name: resource[:name],
+      type: resource[:type],
+      isDefault: (resource[:is_default] == :true),
+      sendReminder: (resource[:send_reminder] == :true),
+      frequency: resource[:frequency],
+      settings: resource[:settings]
+    }
+
+    if notification.nil?
+      response = send_request('POST', format('%s/alert-notifications', resource[:grafana_api_path]), data)
+    else
+      data[:id] = notification[:id]
+      response = send_request 'PUT', format('%s/alert-notifications/%s', resource[:grafana_api_path], notification[:id]), data
+    end
+    if response.code != '200'
+      raise format('Failed to create save %s (HTTP response: %s/%s)', resource[:name], response.code, response.body)
+    end
+    self.notification = nil
+  end
+
+  def delete_notification
+    response = send_request 'DELETE', format('%s/alert-notifications/%s', resource[:grafana_api_path], notification[:id])
+
+    if response.code != '200'
+      raise format('Failed to delete notification %s (HTTP response: %s/%s', resource[:name], response.code, response.body)
+    end
+    self.notification = nil
+  end
+
+  def create
+    save_notification
+  end
+
+  def destroy
+    delete_notification
+  end
+
+  def exists?
+    notification
+  end
+end

--- a/lib/puppet/type/grafana_notification.rb
+++ b/lib/puppet/type/grafana_notification.rb
@@ -1,0 +1,75 @@
+#    Copyright 2015 Mirantis, Inc.
+#
+Puppet::Type.newtype(:grafana_notification) do
+  @doc = 'Manage notification in Grafana'
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'The name of the notification.'
+  end
+
+  newparam(:grafana_api_path) do
+    desc 'The absolute path to the API endpoint'
+    defaultto '/api'
+
+    validate do |value|
+      unless value =~ %r{^/.*/?api$}
+        raise ArgumentError, format('%s is not a valid API path', value)
+      end
+    end
+  end
+
+  newparam(:grafana_url) do
+    desc 'The URL of the Grafana server'
+    defaultto ''
+
+    validate do |value|
+      unless value =~ %r{^https?://}
+        raise ArgumentError, format('%s is not a valid URL', value)
+      end
+    end
+  end
+
+  newparam(:grafana_user) do
+    desc 'The username for the Grafana server'
+  end
+
+  newparam(:grafana_password) do
+    desc 'The password for the Grafana server'
+  end
+
+  newproperty(:type) do
+    desc 'The notification type'
+  end
+
+  newproperty(:is_default) do
+    desc 'Whether the notification is the default one'
+    newvalues(:true, :false)
+    defaultto :false
+  end
+
+  newproperty(:send_reminder) do
+    desc 'Whether automatic message resending is enabled or not'
+    newvalues(:true, :false)
+    defaultto :false
+  end
+
+  newproperty(:frequency) do
+    desc 'The notification reminder frequency'
+  end
+
+  newproperty(:settings) do
+    desc 'Additional JSON data to configure the notification'
+
+    validate do |value|
+      unless value.nil? || value.is_a?(Hash)
+        raise ArgumentError, 'settings should be a Hash!'
+      end
+    end
+  end
+
+  autorequire(:service) do
+    'grafana-server'
+  end
+end

--- a/spec/unit/puppet/type/grafana_notification_type_spec.rb
+++ b/spec/unit/puppet/type/grafana_notification_type_spec.rb
@@ -1,0 +1,72 @@
+# Copyright 2015 Mirantis, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require 'spec_helper'
+
+describe Puppet::Type.type(:grafana_notification) do
+  let(:gnotification) do
+    described_class.new(
+      name: 'foo',
+      grafana_url: 'http://example.com',
+      type: 'email',
+      is_default: true,
+      send_reminder: true,
+      frequency: '20m',
+      settings: { adresses: 'test@example.com' }
+    )
+  end
+
+  context 'when setting parameters' do
+    it "fails if grafana_url isn't HTTP-based" do
+      expect do
+        described_class.new name: 'foo', grafana_url: 'example.com', content: '{}'
+      end.to raise_error(Puppet::Error, %r{not a valid URL})
+    end
+
+    it "fails if settings isn't valid" do
+      expect do
+        described_class.new name: 'foo', grafana_url: 'http://example.com', settings: 'invalid'
+      end.to raise_error(Puppet::Error, %r{settings should be a Hash})
+    end
+
+    # rubocop:disable RSpec/MultipleExpectations
+    it 'accepts valid parameters' do
+      expect(gnotification[:name]).to eq('foo')
+      expect(gnotification[:grafana_url]).to eq('http://example.com')
+      expect(gnotification[:type]).to eq('email')
+      expect(gnotification[:is_default]).to eq(:true)
+      expect(gnotification[:send_reminder]).to eq(:true)
+      expect(gnotification[:frequency]).to eq('20m')
+      expect(gnotification[:settings]).to eq(adresses: 'test@example.com')
+    end
+    # rubocop:enable RSpec/MultipleExpectations
+
+    it 'autorequires the grafana-server for proper ordering' do
+      catalog = Puppet::Resource::Catalog.new
+      service = Puppet::Type.type(:service).new(name: 'grafana-server')
+      catalog.add_resource service
+      catalog.add_resource gnotification
+
+      relationship = gnotification.autorequire.find do |rel|
+        (rel.source.to_s == 'Service[grafana-server]') && (rel.target.to_s == gnotification.to_s)
+      end
+      expect(relationship).to be_a Puppet::Relationship
+    end
+
+    it 'does not autorequire the service it is not managed' do
+      catalog = Puppet::Resource::Catalog.new
+      catalog.add_resource gnotification
+      expect(gnotification.autorequire).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds the ability to manage  notification channels (example.com/grafana/alerting/notifications) using the new ressource grafana_notification.
As others puppet-grafana resources, it uses Grafana API to manages them.
Applicable settings have been described in README.md.
Please note it is my first PR to VoxPopuli, I hope it does comply with all requested rules. If not, I will be happy to amend my work accordingly.

#### This Pull Request (PR) fixes the following issues
N/A