### PR TITLE
Add a task for setting the admin user's password

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 1. [Usage](#usage)
     * [Classes and Defined Types](#classes-and-defined-types)
     * [Advanced usage](#advanced-usage)
+1. [Tasks](#tasks)
 1. [Limitations](#limitations)
 1. [Copyright and License](#copyright-and-license)
 
@@ -863,6 +864,20 @@ point to a locally available directory on the filesystem, typically
 the filesystem of the puppetserver/master. Thus you may specify a
 local directory with grafana dashboards you wish to provision into
 grafana.
+
+## Tasks
+
+### `change_grafana_admin_password`
+
+`old_password`: the old admin password
+
+`new_password`: the password you want to use for the admin user
+
+`uri`: `http` or `https`
+
+`port`: the port Grafana runs on locally
+
+This task can be used to change the password for the admin user in grafana
 
 ## Limitations
 

--- a/tasks/change_grafana_admin_password.json
+++ b/tasks/change_grafana_admin_password.json
@@ -1,0 +1,25 @@
+{
+  "puppet_task_version": 1,
+  "supports_noop": false,
+  "description": "Change the Grafana admin user's password",
+  "parameters": {
+    "old_password": {
+      "description": "The old admin password",
+      "type": "Optional[String[1]]",
+      "sensitive": true
+    },
+    "new_password": {
+      "description": "The new admin password",
+      "type": "Optional[String[1]]",
+      "sensitive": true
+    },
+    "uri": {
+      "description": "http or https",
+      "type": "Enum['http','https']"
+    },
+    "port": {
+      "description": "The port Grafana is running on",
+      "type": "Integer"
+    }
+  }
+}

--- a/tasks/change_grafana_admin_password.sh
+++ b/tasks/change_grafana_admin_password.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+payload="{
+    \"oldPassword\": \"$PT_old_password\",
+    \"newPassword\": \"$PT_new_password\",
+    \"confirmNew\": \"$PT_new_password\"
+}"
+
+cmd="/usr/bin/curl -X PUT -H 'Content-Type: application/json' -d '$payload' '$PT_uri://admin:$PT_old_password@localhost:$PT_port/api/user/password'"
+eval "$cmd"


### PR DESCRIPTION
The task will forcefully set the admin user's password and does not
require knowing the old password.