### PR TITLE
Corrected invalid database config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ result in...
           http_port     => 8080,
         },
         database => {
-          type          => 'sqlite3',
+          type          => 'mysql',
           host          => '127.0.0.1:3306',
           name          => 'grafana',
           user          => 'root',


### PR DESCRIPTION
According to the Grafana documentation [0] the fields host, user and password are not applicable for the database type sqlite. I changed the example's database type to mysql for which these keys are valid.

[0]: http://docs.grafana.org/installation/configuration/#database