### PR TITLE
Add FreeBSD 12 support

### DIFF
--- a/data/family/FreeBSD.yaml
+++ b/data/family/FreeBSD.yaml
@@ -1,0 +1,7 @@
+---
+grafana::cfg_location: '/usr/local/etc/grafana.ini'
+grafana::data_dir: '/var/db/grafana',
+grafana::install_method: 'repo'
+grafana::manage_package_repo: false
+grafana::package_name: 'grafana6'
+grafana::service_name: 'grafana'

--- a/data/family/FreeBSD.yaml
+++ b/data/family/FreeBSD.yaml
@@ -1,6 +1,6 @@
 ---
 grafana::cfg_location: '/usr/local/etc/grafana.ini'
-grafana::data_dir: '/var/db/grafana',
+grafana::data_dir: '/var/db/grafana'
 grafana::install_method: 'repo'
 grafana::manage_package_repo: false
 grafana::package_name: 'grafana6'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -151,8 +151,9 @@ class grafana::install {
           }
         }
         'FreeBSD': {
-          package { 'fontconfig':
-            ensure => 'present',
+          package { 'grafana':
+            ensure  => 'present', # pkgng provider doesn't have feature versionable
+            name    => $grafana::package_name,
           }
         }
         default: {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -153,7 +153,6 @@ class grafana::install {
         'FreeBSD': {
           package { 'fontconfig':
             ensure => 'present',
-            ensure => present,
           }
         }
         default: {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -150,6 +150,12 @@ class grafana::install {
             name   => $grafana::package_name,
           }
         }
+        'FreeBSD': {
+          package { 'fontconfig':
+            ensure => 'present',
+            ensure => present,
+          }
+        }
         default: {
           fail("${facts['os']['name']} not supported")
         }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -59,6 +59,13 @@ class grafana::install {
             require  => Package['fontconfig'],
           }
         }
+        'FreeBSD': {
+          package { 'grafana':
+            ensure   => present,
+            name     => $grafana::package_name,
+            provider => 'pkgng',
+          }
+        }
         default: {
           fail("${facts['os']['family']} not supported")
         }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -152,8 +152,8 @@ class grafana::install {
         }
         'FreeBSD': {
           package { 'grafana':
-            ensure  => 'present', # pkgng provider doesn't have feature versionable
-            name    => $grafana::package_name,
+            ensure => 'present', # pkgng provider doesn't have feature versionable
+            name   => $grafana::package_name,
           }
         }
         default: {

--- a/metadata.json
+++ b/metadata.json
@@ -48,6 +48,9 @@
     },
     {
       "operatingsystem": "Archlinux"
+    },
+    {
+      "operatingsystem": "FreeBSD"
     }
   ],
   "requirements": [

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -169,8 +169,23 @@ describe 'grafana' do
           it { is_expected.to contain_user('grafana').that_comes_before('File[/usr/share/grafana]') }
         end
 
-        describe 'create data_dir' do
-          it { is_expected.to contain_file('/var/lib/grafana').with_ensure('directory') }
+        case facts[:osfamily]
+        when 'Archlinux'
+          describe 'create data_dir' do
+            it { is_expected.to contain_file('/var/lib/grafana').with_ensure('directory') }
+          end
+        when 'Debian'
+          describe 'create data_dir' do
+            it { is_expected.to contain_file('/var/lib/grafana').with_ensure('directory') }
+          end
+        when 'FreBSD'
+          describe 'create data_dir' do
+            it { is_expected.to contain_file('/var/db/grafana').with_ensure('directory') }
+          end
+        when 'RedHat'
+          describe 'create data_dir' do
+            it { is_expected.to contain_file('/var/lib/grafana').with_ensure('directory') }
+          end
         end
 
         describe 'manage install_dir' do


### PR DESCRIPTION
We have everything to run this module on FreeBSD
using pkg/repo install_method.
It would be very nice to have this module available
for FreeBSD users ( no need to mark it as supported platform
in metadata.json )

Tested on: FreeBSD 12.0-RELEASE, FreeBSD 13-HEAD

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
