### PR TITLE
Don't manage dashboard path when puppetsource is not set

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -113,15 +113,16 @@ class grafana::config {
               before => File[$options['path']],
             }
           }
-
-          file { $options['path'] :
-            ensure  => directory,
-            owner   => 'grafana',
-            group   => 'grafana',
-            mode    => '0750',
-            recurse => true,
-            purge   => true,
-            source  => $options['puppetsource'],
+          if ('puppetsource' in $options) {
+            file { $options['path'] :
+              ensure  => directory,
+              owner   => 'grafana',
+              group   => 'grafana',
+              mode    => '0750',
+              recurse => true,
+              purge   => true,
+              source  => $options['puppetsource'],
+            }
           }
         }
       }


### PR DESCRIPTION

#### Pull Request (PR) description

I manage the dashboard provider path with vcsrepo. 
This path is however also managed in config.pp and will purge every file after it is cloned.

The path should not be managed from config.pp if puppetsource is not set in my opinion.

#### This Pull Request (PR) fixes the following issues

#186
