### PR TITLE
Fix #104 - User password set on each puppet run

### DIFF
--- a/lib/puppet/type/grafana_user.rb
+++ b/lib/puppet/type/grafana_user.rb
@@ -43,6 +43,9 @@ Puppet::Type.newtype(:grafana_user) do
 
   newproperty(:password) do
     desc 'The password for the user'
+    def insync?(_is)
+      provider.check_password
+    end
   end
 
   newproperty(:email) do


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes the issue that on each puppet run the user password will be set. 
As the grafana api does not provide any feature for that we try to connect as that user if login works we suppress the password change. 

#### This Pull Request (PR) fixes the following issues
Fixes #104 