### PR TITLE
Add mechanism to make API changes once API is available

### DIFF
--- a/lib/puppet/provider/grafana_conn_validator/net_http.rb
+++ b/lib/puppet/provider/grafana_conn_validator/net_http.rb
@@ -1,0 +1,68 @@
+# See: #10295 for more details.
+#
+# This is a workaround for bug: #4248 whereby ruby files outside of the normal
+# provider/type path do not load until pluginsync has occured on the puppetmaster
+#
+# In this case I'm trying the relative path first, then falling back to normal
+# mechanisms. This should be fixed in future versions of puppet but it looks
+# like we'll need to maintain this for some time perhaps.
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', '..', '..'))
+require 'puppet/util/grafana_conn_validator'
+
+# This file contains a provider for the resource type `grafana_conn_validator`,
+# which validates the Grafana API connection by attempting an http(s) connection.
+
+Puppet::Type.type(:grafana_conn_validator).provide(:net_http) do
+  desc "A provider for the resource type `grafana_conn_validator`,
+        which validates the Grafana API connection by attempting an http(s)
+        connection to the Grafana server."
+
+  # Test to see if the resource exists, returns true if it does, false if it
+  # does not.
+  #
+  # Here we simply monopolize the resource API, to execute a test to see if the
+  # database is connectable. When we return a state of `false` it triggers the
+  # create method where we can return an error message.
+  #
+  # @return [bool] did the test succeed?
+  def exists?
+    start_time = Time.now
+    timeout = resource[:timeout]
+
+    success = validator.attempt_connection
+
+    while success == false && ((Time.now - start_time) < timeout)
+      # It can take several seconds for the Grafana server to start up;
+      # especially on the first install.  Therefore, our first connection attempt
+      # may fail.  Here we have somewhat arbitrarily chosen to retry every 2
+      # seconds until the configurable timeout has expired.
+      Puppet.notice('Failed to connect to Grafana API; sleeping 2 seconds before retry')
+      sleep 2
+      success = validator.attempt_connection
+    end
+
+    unless success
+      Puppet.notice("Failed to connect to Grafana within timeout window of #{timeout} seconds; giving up.")
+    end
+
+    success
+  end
+
+  # This method is called when the exists? method returns false.
+  #
+  # @return [void]
+  def create
+    # If `#create` is called, that means that `#exists?` returned false, which
+    # means that the connection could not be established... so we need to
+    # cause a failure here.
+    raise Puppet::Error, "Unable to connect to Grafana server! (#{@validator.grafana_url})"
+  end
+
+  # Returns the existing validator, if one exists otherwise creates a new object
+  # from the class.
+  #
+  # @api private
+  def validator
+    @validator ||= Puppet::Util::GrafanaConnValidator.new(resource[:grafana_url], resource[:grafana_api_path])
+  end
+end

--- a/lib/puppet/provider/grafana_conn_validator/net_http.rb
+++ b/lib/puppet/provider/grafana_conn_validator/net_http.rb
@@ -1,8 +1,3 @@
-# See: #10295 for more details.
-#
-# This is a workaround for bug: #4248 whereby ruby files outside of the normal
-# provider/type path do not load until pluginsync has occured on the puppetmaster
-#
 # In this case I'm trying the relative path first, then falling back to normal
 # mechanisms. This should be fixed in future versions of puppet but it looks
 # like we'll need to maintain this for some time perhaps.

--- a/lib/puppet/type/grafana_conn_validator.rb
+++ b/lib/puppet/type/grafana_conn_validator.rb
@@ -31,6 +31,11 @@ Puppet::Type.newtype(:grafana_conn_validator) do
     end
   end
 
+  newparam(:timeout) do
+    desc 'How long to wait for the API to be available'
+    defaultto(20)
+  end
+
   autorequire(:service) do
     'grafana-server'
   end

--- a/lib/puppet/type/grafana_conn_validator.rb
+++ b/lib/puppet/type/grafana_conn_validator.rb
@@ -1,0 +1,37 @@
+Puppet::Type.newtype(:grafana_conn_validator) do
+  desc <<-DESC
+  Verify connectivity to the Grafana API
+  DESC
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'Arbitrary name of this resource'
+  end
+
+  newparam(:grafana_url) do
+    desc 'The URL of the Grafana server'
+    defaultto 'http://localhost:3000'
+
+    validate do |value|
+      unless value =~ %r{^https?://}
+        raise ArgumentError, format('%s is not a valid URL', value)
+      end
+    end
+  end
+
+  newparam(:grafana_api_path) do
+    desc 'The absolute path to the API endpoint'
+    defaultto '/api/health'
+
+    validate do |value|
+      unless value =~ %r{^/.*/?api$}
+        raise ArgumentError, format('%s is not a valid API path', value)
+      end
+    end
+  end
+
+  autorequire(:service) do
+    'grafana-server'
+  end
+end

--- a/lib/puppet/type/grafana_conn_validator.rb
+++ b/lib/puppet/type/grafana_conn_validator.rb
@@ -25,7 +25,7 @@ Puppet::Type.newtype(:grafana_conn_validator) do
     defaultto '/api/health'
 
     validate do |value|
-      unless value =~ %r{^/.*/?api$}
+      unless value =~ %r{^/.*/?api/.*$}
         raise ArgumentError, format('%s is not a valid API path', value)
       end
     end

--- a/lib/puppet/type/grafana_dashboard.rb
+++ b/lib/puppet/type/grafana_dashboard.rb
@@ -82,4 +82,8 @@ Puppet::Type.newtype(:grafana_dashboard) do
   autorequire(:service) do
     'grafana-server'
   end
+
+  autorequire(:grafana_conn_validator) do
+    'grafana'
+  end
 end

--- a/lib/puppet/type/grafana_datasource.rb
+++ b/lib/puppet/type/grafana_datasource.rb
@@ -127,4 +127,8 @@ Puppet::Type.newtype(:grafana_datasource) do
   autorequire(:service) do
     'grafana-server'
   end
+
+  autorequire(:grafana_conn_validator) do
+    'grafana'
+  end
 end

--- a/lib/puppet/type/grafana_folder.rb
+++ b/lib/puppet/type/grafana_folder.rb
@@ -51,4 +51,8 @@ Puppet::Type.newtype(:grafana_folder) do
   autorequire(:service) do
     'grafana-server'
   end
+
+  autorequire(:grafana_conn_validator) do
+    'grafana'
+  end
 end

--- a/lib/puppet/type/grafana_notification.rb
+++ b/lib/puppet/type/grafana_notification.rb
@@ -72,4 +72,8 @@ Puppet::Type.newtype(:grafana_notification) do
   autorequire(:service) do
     'grafana-server'
   end
+
+  autorequire(:grafana_conn_validator) do
+    'grafana'
+  end
 end

--- a/lib/puppet/type/grafana_organization.rb
+++ b/lib/puppet/type/grafana_organization.rb
@@ -56,4 +56,8 @@ Puppet::Type.newtype(:grafana_organization) do
   autorequire(:service) do
     'grafana-server'
   end
+
+  autorequire(:grafana_conn_validator) do
+    'grafana'
+  end
 end

--- a/lib/puppet/type/grafana_plugin.rb
+++ b/lib/puppet/type/grafana_plugin.rb
@@ -44,4 +44,8 @@ DESC
       end
     end
   end
+
+  autorequire(:grafana_conn_validator) do
+    'grafana'
+  end
 end

--- a/lib/puppet/type/grafana_plugin.rb
+++ b/lib/puppet/type/grafana_plugin.rb
@@ -44,8 +44,4 @@ DESC
       end
     end
   end
-
-  autorequire(:grafana_conn_validator) do
-    'grafana'
-  end
 end

--- a/lib/puppet/type/grafana_user.rb
+++ b/lib/puppet/type/grafana_user.rb
@@ -67,4 +67,8 @@ Puppet::Type.newtype(:grafana_user) do
   autorequire(:service) do
     'grafana-server'
   end
+
+  autorequire(:grafana_conn_validator) do
+    'grafana'
+  end
 end

--- a/lib/puppet/util/grafana_conn_validator.rb
+++ b/lib/puppet/util/grafana_conn_validator.rb
@@ -22,7 +22,7 @@ module Puppet
         # http(s), so here we're simpling hitting a somewhat arbitrary low-impact URL
         # on the Grafana server.
         grafana_host = URI.parse(@grafana_url).host
-        grafana_port = URI.parse(@grafana_api_path).port
+        grafana_port = URI.parse(@grafana_url).port
         grafana_scheme = URI.parse(@grafana_url).scheme
         http = Net::HTTP.new(grafana_host, grafana_port)
         http.use_ssl = (grafana_scheme == 'https')

--- a/lib/puppet/util/grafana_conn_validator.rb
+++ b/lib/puppet/util/grafana_conn_validator.rb
@@ -1,0 +1,45 @@
+require 'net/http'
+
+module Puppet
+  module Util
+    # Validator class, for testing that Grafana is alive
+    class GrafanaConnValidator
+      attr_reader :grafana_url
+      attr_reader :grafana_api_path
+
+      def initialize(grafana_url, grafana_api_path)
+        @grafana_url      = grafana_url
+        @grafana_api_path = grafana_api_path
+      end
+
+      # Utility method; attempts to make an http/https connection to the Grafana server.
+      # This is abstracted out into a method so that it can be called multiple times
+      # for retry attempts.
+      #
+      # @return true if the connection is successful, false otherwise.
+      def attempt_connection
+        # All that we care about is that we are able to connect successfully via
+        # http(s), so here we're simpling hitting a somewhat arbitrary low-impact URL
+        # on the Grafana server.
+        grafana_host = URI.parse(@grafana_url).host
+        grafana_port = URI.parse(@grafana_api_path).port
+        grafana_scheme = URI.parse(@grafana_url).scheme
+        http = Net::HTTP.new(grafana_host, grafana_port)
+        http.use_ssl = (grafana_scheme == 'https')
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        request = Net::HTTP::Get.new(@grafana_api_path)
+        request.add_field('Accept', 'application/json')
+        response = http.request(request)
+
+        unless response.is_a?(Net::HTTPSuccess) || response.is_a?(Net::HTTPUnauthorized)
+          Puppet.notice "Unable to connect to Grafana server (#{grafana_scheme}://#{grafana_host}:#{grafana_port}): [#{response.code}] #{response.msg}"
+          return false
+        end
+        return true
+      rescue Exception => e # rubocop:disable Lint/RescueException
+        Puppet.notice "Unable to connect to Grafana server (#{grafana_scheme}://#{grafana_host}:#{grafana_port}): #{e.message}"
+        return false
+      end
+    end
+  end
+end

--- a/manifests/validator.pp
+++ b/manifests/validator.pp
@@ -1,17 +1,9 @@
-# == Class: grafana::validator
+# @summary Manage grafana_conn_validator resource
 #
-# Includes `` resource
-#
-# === Parameters
-# [*grafana_url*]
-# Grafana URL.
-#
-# [*grafana_api_path*]
-# API path to validate with.
-#
-# === Examples
-#
-#  include grafana::validator
+# @param grafana_url
+#   Grafana URL.
+# @param grafana_api_path
+#   API path to validate with.
 #
 class grafana::validator (
   Stdlib::HTTPUrl $grafana_url = 'http://localhost:3000',

--- a/manifests/validator.pp
+++ b/manifests/validator.pp
@@ -1,0 +1,25 @@
+# == Class: grafana::validator
+#
+# Includes `` resource
+#
+# === Parameters
+# [*grafana_url*]
+# Grafana URL.
+#
+# [*grafana_api_path*]
+# API path to validate with.
+#
+# === Examples
+#
+#  include grafana::validator
+#
+class grafana::validator (
+  String[1] $grafana_url = 'http://localhost:3000',
+  String[1] $grafana_api_path = '/api/health',
+) {
+
+  grafana_conn_validator { 'grafana':
+    grafana_url      => $grafana_url,
+    grafana_api_path => $grafana_api_path,
+  }
+}

--- a/manifests/validator.pp
+++ b/manifests/validator.pp
@@ -14,8 +14,8 @@
 #  include grafana::validator
 #
 class grafana::validator (
-  String[1] $grafana_url = 'http://localhost:3000',
-  String[1] $grafana_api_path = '/api/health',
+  Stdlib::HTTPUrl $grafana_url = 'http://localhost:3000',
+  Stdlib::Absolutepath $grafana_api_path = '/api/health',
 ) {
 
   grafana_conn_validator { 'grafana':

--- a/spec/acceptance/grafana_folder_spec.rb
+++ b/spec/acceptance/grafana_folder_spec.rb
@@ -21,6 +21,7 @@ describe 'grafana_folder' do
   context 'create folder resource' do
     it 'creates the folder' do
       pp = <<-EOS
+      include grafana::validator
       grafana_folder { 'example-folder':
         ensure           => present,
         grafana_url      => 'http://localhost:3000',
@@ -42,6 +43,7 @@ describe 'grafana_folder' do
   context 'create folder containing dashboard' do
     it 'creates an example dashboard in the example folder' do
       pp = <<-EOS
+      include grafana::validator
       grafana_dashboard { 'example-dashboard':
         ensure           => present,
         grafana_url      => 'http://localhost:3000',
@@ -65,6 +67,7 @@ describe 'grafana_folder' do
   context 'destroy resources' do
     it 'destroys the folders and dashboard' do
       pp = <<-EOS
+      include grafana::validator
       grafana_folder { 'example-folder':
         ensure           => absent,
         grafana_url      => 'http://localhost:3000',

--- a/spec/acceptance/grafana_plugin_spec.rb
+++ b/spec/acceptance/grafana_plugin_spec.rb
@@ -5,6 +5,7 @@ describe 'grafana_plugin' do
     it 'runs successfully' do
       pp = <<-EOS
       class { 'grafana':}
+      include grafana::validator
       grafana_plugin { 'grafana-simple-json-datasource': }
       EOS
       apply_manifest(pp, catch_failures: true)
@@ -22,6 +23,7 @@ describe 'grafana_plugin' do
     it 'runs successfully' do
       pp = <<-EOS
       class { 'grafana':}
+      include grafana::validator
       grafana_plugin { 'grafana-simple-json-datasource':
         ensure => present,
         repo   => 'https://nexus.company.com/grafana/plugins',
@@ -42,6 +44,7 @@ describe 'grafana_plugin' do
     it 'runs successfully' do
       pp = <<-EOS
       class { 'grafana':}
+      include grafana::validator
       grafana_plugin { 'grafana-simple-json-datasource':
         ensure => absent,
       }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
Add a type that can verify the API is available before attempting to make API calls. Having autorequire on a service isn't enough. I've run into this already where service restarts but something like `grafana_folder` will try to use API before Grafana is ready.

This is nearly identical approach taken from PuppetDB module from Puppetlabs and Sensu's sensu module.

I made it opt-in by making a dedicated class for the validator to be included.  It won't make sense to opt-in to this by default until some improvements are made to DRY up the way `grafana_url` and duplicate items are passed to the various types.