### PR TITLE
Support for teams, dashboard permissions and memberships

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,8 @@ If you are using a sub-path for the Grafana API, you will need to set the `grafa
 - `grafana_organization`
 - `grafana_user`
 - `grafana_folder`
+- `grafana_team`
+- `grafana_membership`
 
 For instance, if your sub-path is `/grafana`, the `grafana_api_path` must
 be set to `/grafana/api`. Do not add a trailing `/` (slash) at the end of the value.
@@ -432,6 +434,113 @@ grafana_organization { 'example_org':
 `name` is optional if the name will differ from example_org above.
 
 `address` is an optional parameter that requires a hash. Address settings are `{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}`
+
+#### `grafana_team`
+
+In order to use the team resource, add the following to your manifest:
+
+```puppet
+grafana_team { 'example_team':
+  grafana_url      => 'http://localhost:3000',
+  grafana_user     => 'admin',
+  grafana_password => '5ecretPassw0rd',
+  home_dashboard   => 'example_dashboard',
+  organization     => 'example_org',
+}
+```
+
+Organziation must exist if specified.
+
+`grafana_url`, `grafana_user`, and `grafana_password` are required to create teams via the API.
+
+`name` is optional if the name will differ from example_team above.
+
+`home_dashboard` is optional. Sets the home dashboard for team. Dashboard must exist.
+
+`organization` is optional. Defaults to `Main org.`
+
+`ensure` is optional. If the resource should be `present` or `absent`
+
+#### `grafana_dashboard_permission`
+
+In order to use the dashboard permission resource, add one the following to your manifest:
+
+add permissions for user:
+
+```puppet
+grafana_dashboard_permission { 'example_user_permission':
+  grafana_url      => 'http://localhost:3000',
+  grafana_user     => 'admin',
+  grafana_password => '5ecretPassw0rd',
+  dashboard        => 'example_dashboard',
+  user             => 'example_user',
+  organization     => 'example_org',
+}
+```
+
+add permissions for team:
+
+```puppet
+grafana_dashboard_permission { 'example_team_permission':
+  grafana_url      => 'http://localhost:3000',
+  grafana_user     => 'admin',
+  grafana_password => '5ecretPassw0rd',
+  dashboard        => 'example_dashboard',
+  team             => 'example_team',
+  organization     => 'example_org',
+}
+```
+
+Organziation, team, user and dashboard must exist if specified.
+
+`grafana_url`, `grafana_user`, and `grafana_password` are required to create teams via the API.
+
+`dashboard` is required. The dashboard to set permissions for.
+
+`user` is required if `team` not set. The user to add permissions for.
+
+`team` is required if `user` not set. the team to add permissions for.
+
+`name` is optional if the name will differ from example_team above.
+
+`organization` is optional. Defaults to `Main org.`
+
+`ensure` is optional. If the resource should be `present` or `absent`
+
+#### `grafana_membership`
+
+In order to use the membership resource, add the following to your manifest:
+
+```puppet
+grafana_membership { 'example_membership':
+  grafana_url      => 'http://localhost:3000',
+  grafana_user     => 'admin',
+  grafana_password => '5ecretPassw0rd',
+  membership_type => 'team',
+  organization    => 'example_org',
+  target_name     => 'example_team',
+  user_name       => 'example_user',
+  role            => 'Viewer'
+  }
+}
+```
+A membership is the concept of a user belonging to a target - either a `team` or an `organization`
+
+The user and target must both exist for a membership to be created
+
+`grafana_url`, `grafana_user`, and `grafana_password` are required to create memberships via the API.
+
+`membership_type` is required. Either `team` or `organization`
+
+`target_name` is required. Specifies the target of the membership.
+
+`user_name` is required. Specifies the user that is the focus of the membership.
+
+`role` is required. Specifies what rights to grant the user. Either `Viewer`, `Editor` or `Admin`
+
+`organization` is optional when using the `membership_type` of `team`. Defaults to `Main org.`
+
+`ensure` is optional. If the resource should be `present` or `absent`
 
 #### `grafana_dashboard`
 

--- a/lib/puppet/provider/grafana_dashboard_permission/grafana.rb
+++ b/lib/puppet/provider/grafana_dashboard_permission/grafana.rb
@@ -1,0 +1,264 @@
+# frozen_string_literal: true
+
+require 'json'
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'grafana'))
+
+Puppet::Type.type(:grafana_dashboard_permission).provide(:grafana, parent: Puppet::Provider::Grafana) do
+  desc 'Support for Grafana dashboard permissions'
+
+  defaultfor kernel: 'Linux'
+
+  def grafana_api_path
+    resource[:grafana_api_path]
+  end
+
+  def set_current_organization
+    response = send_request 'POST', format('%s/user/using/%s', grafana_api_path, organization[:id])
+    return if response.code == '200'
+
+    raise format('Failed to switch to org %s (HTTP response: %s/%s)', organization[:id], response.code, response.body)
+  end
+
+  def raise_on_error(code, message)
+    raise message if code != '200'
+  end
+
+  def parse_response(data)
+    JSON.parse(data)
+  rescue JSON::ParserError
+    raise format('Fail to parse response: %s', response.body)
+  end
+
+  def map_organizations(ids)
+    ids.map do |id|
+      response = send_request 'GET', format('%s/orgs/%s', grafana_api_path, id)
+      raise_on_error(response.code, format('Failed to retrieve organization %d (HTTP response: %s/%s)', id, response.code, response.body))
+
+      organization = parse_response(response.body)
+      {
+        id: organization['id'],
+        name: organization['name']
+      }
+    end
+  end
+
+  def organizations
+    response = send_request('GET', format('%s/orgs', grafana_api_path))
+    raise_on_error(response.code, format('Fail to retrieve organizations (HTTP response: %s/%s)', response.code, response.body))
+    organizations = JSON.parse(response.body)
+    map_organizations(organizations.map { |x| x['id'] })
+  end
+
+  def organization
+    return @organization if @organization
+
+    org = resource[:organization]
+    key = org.is_a?(Numeric) || org.match(%r{/^[0-9]*$/}) ? :id : :name
+    @organization = organizations.find { |x| x[key] == org }
+  end
+
+  def map_teams(teams)
+    teams['teams'].map do |team|
+      {
+        id: team['id'],
+        name: team['name'],
+        organization: team['orgId'],
+        membercount: team['membercount'],
+        permission: team['permission'],
+        email: team['email']
+      }
+    end
+  end
+
+  def teams
+    raise(format('Unknown Organization: %s', resource[:organization])) unless organization
+
+    set_current_organization
+    response = send_request('GET', format('%s/teams/search', grafana_api_path))
+    raise_on_error(response.code, format('Fail to retrieve teams (HTTP response: %s/%s)', response.code, response.body))
+    teams = parse_response(response.body)
+    map_teams(teams)
+  end
+
+  def team
+    @team ||= teams.find { |x| x[:name] == resource[:team] }
+  end
+
+  def send_users_request
+    raise(format('Unknown Organization: %s', resource[:organization])) unless organization
+
+    set_current_organization
+    response = send_request('GET', format('%s/org/users', grafana_api_path))
+    raise_on_error(response.code, format('Fail to retrieve users (HTTP response: %s/%s)', response.code, response.body))
+    response.body
+  end
+
+  def users
+    users = parse_response(send_users_request)
+    users.map do |user|
+      {
+        id: user['userId'],
+        name: user['login'],
+        organization: user['orgId'],
+        role: user['role']
+      }
+    end
+  end
+
+  def user
+    @user ||= users.find { |x| x[:name] == resource[:user] }
+  end
+
+  def dashboards
+    set_current_organization
+    search_path = { query: resource[:dashboard], type: 'dash-db' }
+    response = send_request('GET', format('%s/search', grafana_api_path), nil, search_path)
+    raise_on_error(response.code, format('Fail to retrieve dashboards (HTTP response: %s/%s)', response.code, response.body))
+    dashboards = parse_response(response.body)
+    dashboards.map do |dashboard|
+      {
+        id: dashboard['id'],
+        name: dashboard['title']
+      }
+    end
+  end
+
+  def dashboard
+    Puppet.info('inside dashboard')
+    @dashboard ||= dashboards.find { |x| x[:name] == resource[:dashboard] }
+  end
+
+  def permissions
+    Puppet.info('inside permissions')
+    return @permissions if @permissions
+    raise(format('Unknown dashboard: %s', resource[:dashboard])) unless dashboard
+
+    response = send_request('GET', format('%s/dashboards/id/%s/permissions', grafana_api_path, dashboard[:id]))
+    raise_on_error(response.code, format('Failed to retrieve permissions on dashboard (HTTP response: %s/%s)', response.code, response.body))
+    permissions = parse_response(response.body)
+    @permissions = permissions.map do |permission|
+      {
+        dashboardId: permission['dashboardId'],
+        userId: permission['userId'],
+        user: permission['userLogin'],
+        teamId: permission['teamId'],
+        team: permission['team'],
+        permissionId: permission['permission'],
+        permission: permission['permissionName'],
+        dashboard: permission['title'],
+        isFolder: permission['isFolder'],
+        inherited: permission['inherited']
+      }
+    end
+  end
+
+  def team_permission
+    Puppet.info('inside team permission')
+    raise(format('Unknown team: %s for organaization: %s', resource[:team], resource[:organization])) unless team
+
+    @team_permission ||= permissions.find { |x| x[:teamId] == team[:id] }
+  end
+
+  def user_permission
+    Puppet.info('inside user permission')
+    raise(format('Unknown user: %s for organaization: %s', resource[:user], resource[:organization])) unless user
+
+    @user_permission ||= permissions.find { |x| x[:userId] == user[:id] }
+  end
+
+  def permission
+    Puppet.info('inside get permission')
+    resource[:user] ? user_permission[:permission] : team_permission[:permission]
+  end
+
+  def permission=(value)
+    case value
+    when 'View'
+      resource[:permission] = 1
+    when 'Edit'
+      resource[:permission] = 2
+    when 'Admin'
+      resource[:permission] = 4
+    end
+    save_permission
+  end
+
+  def new_permission
+    key = resource[:user] ? :userId : :teamId
+    subject_id = resource[:user] ? user[:id] : team[:id]
+    permission = case resource[:permission]
+                 when :View
+                   1
+                 when :Edit
+                   2
+                 when :Admin
+                   4
+                 end
+    raise(format('User or Team must exist')) unless subject_id
+
+    {
+      key => subject_id,
+      'permission' => permission
+    }
+  end
+
+  def remove_unneeded_permissions(obj)
+    obj.delete_if { |k| k['dashboardId'] == -1 }
+    new_target = resource[:user] || resource[:team]
+    new_type = resource[:user] ? :user : :team
+    obj.delete_if { |k| k[new_type] == new_target }
+    obj.delete_if { |k| k[:teamId].zero? && k[:userId].zero? }
+  end
+
+  def existing_permissions
+    perms = remove_unneeded_permissions(permissions)
+    Puppet.info(perms)
+    perms.map do |perm|
+      Puppet.info(perm[:userId])
+      target = perm[:userId].zero? ? perm[:teamId] : perm[:userId]
+      type = perm[:userId].zero? ? :teamId : :userId
+      {
+        type => target,
+        :permission => perm[:permissionId]
+      }
+    end
+  end
+
+  def permission_data(destroy=false)
+    Puppet.info('inside save permission data')
+    raise format('Unknown dashboard: %s', resource[:dashboard]) unless dashboard
+
+    endpoint = format('%s/dashboards/id/%s/permissions', grafana_api_path, dashboard[:id])
+
+    # Puppet.info(existing_permissions)
+    final_permissions = destroy ? { items: existing_permissions } : { items: existing_permissions + [new_permission] }
+    Puppet.info(final_permissions)
+    # Puppet.info(final_permissions)
+    ['POST', endpoint, final_permissions]
+  end
+
+  def save_permission
+    Puppet.info('inside save permission')
+    response = send_request(*permission_data)
+    raise_on_error(response.code, format('Failed to update membership %s, (HTTP response: %s/%s)', resource, response.code, response.body))
+  end
+
+  def create
+    save_permission
+  end
+
+  def destroy
+    Puppet.info('inside destroy permission')
+    response = send_request(*permission_data(true))
+    raise_on_error(response.code, format('Failed to update membership %s, (HTTP response: %s/%s)', resource, response.code, response.body))
+  end
+
+  def exists?
+    raise('user or team parameter must be present') unless resource[:user] || resource[:team]
+
+    Puppet.info('inside exists permission')
+    # Puppet.info(resource[:user])
+    resource[:user] ? user_permission : team_permission
+  end
+end

--- a/lib/puppet/provider/grafana_dashboard_permission/grafana.rb
+++ b/lib/puppet/provider/grafana_dashboard_permission/grafana.rb
@@ -125,12 +125,10 @@ Puppet::Type.type(:grafana_dashboard_permission).provide(:grafana, parent: Puppe
   end
 
   def dashboard
-    Puppet.info('inside dashboard')
     @dashboard ||= dashboards.find { |x| x[:name] == resource[:dashboard] }
   end
 
   def permissions
-    Puppet.info('inside permissions')
     return @permissions if @permissions
     raise(format('Unknown dashboard: %s', resource[:dashboard])) unless dashboard
 
@@ -154,21 +152,18 @@ Puppet::Type.type(:grafana_dashboard_permission).provide(:grafana, parent: Puppe
   end
 
   def team_permission
-    Puppet.info('inside team permission')
     raise(format('Unknown team: %s for organaization: %s', resource[:team], resource[:organization])) unless team
 
     @team_permission ||= permissions.find { |x| x[:teamId] == team[:id] }
   end
 
   def user_permission
-    Puppet.info('inside user permission')
     raise(format('Unknown user: %s for organaization: %s', resource[:user], resource[:organization])) unless user
 
     @user_permission ||= permissions.find { |x| x[:userId] == user[:id] }
   end
 
   def permission
-    Puppet.info('inside get permission')
     resource[:user] ? user_permission[:permission] : team_permission[:permission]
   end
 
@@ -213,9 +208,7 @@ Puppet::Type.type(:grafana_dashboard_permission).provide(:grafana, parent: Puppe
 
   def existing_permissions
     perms = remove_unneeded_permissions(permissions)
-    Puppet.info(perms)
     perms.map do |perm|
-      Puppet.info(perm[:userId])
       target = perm[:userId].zero? ? perm[:teamId] : perm[:userId]
       type = perm[:userId].zero? ? :teamId : :userId
       {
@@ -226,20 +219,15 @@ Puppet::Type.type(:grafana_dashboard_permission).provide(:grafana, parent: Puppe
   end
 
   def permission_data(destroy=false)
-    Puppet.info('inside save permission data')
     raise format('Unknown dashboard: %s', resource[:dashboard]) unless dashboard
 
     endpoint = format('%s/dashboards/id/%s/permissions', grafana_api_path, dashboard[:id])
 
-    # Puppet.info(existing_permissions)
     final_permissions = destroy ? { items: existing_permissions } : { items: existing_permissions + [new_permission] }
-    Puppet.info(final_permissions)
-    # Puppet.info(final_permissions)
     ['POST', endpoint, final_permissions]
   end
 
   def save_permission
-    Puppet.info('inside save permission')
     response = send_request(*permission_data)
     raise_on_error(response.code, format('Failed to update membership %s, (HTTP response: %s/%s)', resource, response.code, response.body))
   end
@@ -249,7 +237,6 @@ Puppet::Type.type(:grafana_dashboard_permission).provide(:grafana, parent: Puppe
   end
 
   def destroy
-    Puppet.info('inside destroy permission')
     response = send_request(*permission_data(true))
     raise_on_error(response.code, format('Failed to update membership %s, (HTTP response: %s/%s)', resource, response.code, response.body))
   end
@@ -257,8 +244,6 @@ Puppet::Type.type(:grafana_dashboard_permission).provide(:grafana, parent: Puppe
   def exists?
     raise('user or team parameter must be present') unless resource[:user] || resource[:team]
 
-    Puppet.info('inside exists permission')
-    # Puppet.info(resource[:user])
     resource[:user] ? user_permission : team_permission
   end
 end

--- a/lib/puppet/provider/grafana_dashboard_permission/grafana.rb
+++ b/lib/puppet/provider/grafana_dashboard_permission/grafana.rb
@@ -218,7 +218,7 @@ Puppet::Type.type(:grafana_dashboard_permission).provide(:grafana, parent: Puppe
     end
   end
 
-  def permission_data(destroy=false)
+  def permission_data(destroy = false)
     raise format('Unknown dashboard: %s', resource[:dashboard]) unless dashboard
 
     endpoint = format('%s/dashboards/id/%s/permissions', grafana_api_path, dashboard[:id])

--- a/lib/puppet/provider/grafana_membership/grafana.rb
+++ b/lib/puppet/provider/grafana_membership/grafana.rb
@@ -35,9 +35,6 @@ Puppet::Type.type(:grafana_membership).provide(:grafana, parent: Puppet::Provide
     org = resource[:membership_type] == :organization ? resource[:target_name] : resource[:organization]
     key = org.is_a?(Numeric) || org.match(%r{/^[0-9]*$/}) ? :id : :name
     @organization = organizations.find { |x| x[key] == org }
-    # return @organization if @organization
-
-    # raise format('Unknown organization: %s', org)
   end
 
   def map_teams(teams)
@@ -64,12 +61,7 @@ Puppet::Type.type(:grafana_membership).provide(:grafana, parent: Puppet::Provide
   end
 
   def team
-    # return @team if @team
-
     @team ||= teams.find { |x| x[:name] == resource[:target_name] }
-    # return @team if @team
-
-    # raise format('Unknown team: %s', resource[:target_name])
   end
 
   def map_team_members(members)
@@ -134,9 +126,6 @@ Puppet::Type.type(:grafana_membership).provide(:grafana, parent: Puppet::Provide
 
   def user
     @user ||= users.find { |x| x[:name] == resource[:user_name] }
-    # return @user if @user
-
-    # raise format('Unknown user: %s', resource[:user_name])
   end
 
   def set_current_organization

--- a/lib/puppet/provider/grafana_membership/grafana.rb
+++ b/lib/puppet/provider/grafana_membership/grafana.rb
@@ -1,0 +1,252 @@
+# frozen_string_literal: true
+
+require 'json'
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'grafana'))
+
+Puppet::Type.type(:grafana_membership).provide(:grafana, parent: Puppet::Provider::Grafana) do
+  desc 'Support for Grafana memberships'
+
+  defaultfor kernel: 'Linux'
+
+  def map_organizations(ids)
+    ids.map do |id|
+      response = send_request 'GET', format('%s/orgs/%s', resource[:grafana_api_path], id)
+      raise_on_error(response.code, format('Failed to retrieve organization %d (HTTP response: %s/%s)', id, response.code, response.body))
+
+      organization = parse_response(response.body)
+      {
+        id: organization['id'],
+        name: organization['name']
+      }
+    end
+  end
+
+  def organizations
+    response = send_request('GET', format('%s/orgs', resource[:grafana_api_path]))
+    raise_on_error(response.code, format('Fail to retrieve organizations (HTTP response: %s/%s)', response.code, response.body))
+    organizations = JSON.parse(response.body)
+    map_organizations(organizations.map { |x| x['id'] })
+  end
+
+  def organization
+    return @organization if @organization
+
+    org = resource[:membership_type] == :organization ? resource[:target_name] : resource[:organization]
+    key = org.is_a?(Numeric) || org.match(%r{/^[0-9]*$/}) ? :id : :name
+    @organization = organizations.find { |x| x[key] == org }
+    # return @organization if @organization
+
+    # raise format('Unknown organization: %s', org)
+  end
+
+  def map_teams(teams)
+    teams['teams'].map do |team|
+      {
+        id: team['id'],
+        name: team['name'],
+        organization: team['orgId'],
+        membercount: team['membercount'],
+        permission: team['permission'],
+        email: team['email']
+      }
+    end
+  end
+
+  def teams
+    return {} unless organization
+
+    set_current_organization
+    response = send_request('GET', format('%s/teams/search', resource[:grafana_api_path]))
+    raise_on_error(response.code, format('Fail to retrieve teams (HTTP response: %s/%s)', response.code, response.body))
+    teams = parse_response(response.body)
+    map_teams(teams)
+  end
+
+  def team
+    # return @team if @team
+
+    @team ||= teams.find { |x| x[:name] == resource[:target_name] }
+    # return @team if @team
+
+    # raise format('Unknown team: %s', resource[:target_name])
+  end
+
+  def map_team_members(members)
+    members.map do |member|
+      {
+        id: member['userId'],
+        target_name: member['teamId'],
+        organization: member['orgId']
+      }
+    end
+  end
+
+  def team_members
+    response = send_request('GET', format('%s/teams/%s/members', resource[:grafana_api_path], @team[:id]))
+    raise_on_error(response.code, format('Fail to retrieve teams (HTTP response: %s/%s)', response.code, response.body))
+    members = parse_response(response.body)
+    members ? map_team_members(members) : []
+  end
+
+  def team_member
+    @team_member ||= team_members.find { |x| x[:id] == @user[:id] }
+  end
+
+  def raise_on_error(code, message)
+    raise message if code != '200'
+  end
+
+  def grafana_api_path
+    resource[:grafana_api_path]
+  end
+
+  def parse_response(data)
+    JSON.parse(data)
+  rescue JSON::ParserError
+    raise format('Fail to parse response: %s', response.body)
+  end
+
+  def send_users_request
+    return '[]' unless organization
+
+    set_current_organization
+    response = send_request('GET', format('%s/org/users', grafana_api_path))
+    raise_on_error(response.code, format('Fail to retrieve users (HTTP response: %s/%s)', response.code, response.body))
+    response.body
+  end
+
+  def map_users(users)
+    users.map do |user|
+      {
+        id: user['userId'],
+        name: user['login'],
+        organization: user['orgId'],
+        role: user['role']
+      }
+    end
+  end
+
+  def users
+    users = parse_response(send_users_request)
+    map_users(users)
+  end
+
+  def user
+    @user ||= users.find { |x| x[:name] == resource[:user_name] }
+    # return @user if @user
+
+    # raise format('Unknown user: %s', resource[:user_name])
+  end
+
+  def set_current_organization
+    response = send_request 'POST', format('%s/user/using/%s', resource[:grafana_api_path], organization[:id])
+    return if response.code == '200'
+
+    raise format('Failed to switch to org %s (HTTP response: %s/%s)', organization[:id], response.code, response.body)
+  end
+
+  def role
+    user unless @user
+    return @user[:role] if @user
+
+    nil
+  end
+
+  def role=(value)
+    resource[:role] = value
+    save_membership
+  end
+
+  def save_membership
+    send(format('save_membership_%s', resource[:membership_type]))
+  end
+
+  def check_org_team_and_user_exist
+    raise(format('Unknown organization: %s', resource[:organization])) unless organization
+
+    set_current_organization
+    raise('Unknown team or user') unless team && user
+  end
+
+  def save_membership_team
+    check_org_team_and_user_exist
+    endpoint = format('%s/teams/%s/members', resource[:grafana_api_path], @team[:id])
+    response = send_request('POST', endpoint, userId: @user[:id])
+    raise_on_error(response.code, format('Failed to update membership %s, (HTTP response: %s/%s)', resource, response.code, response.body))
+  end
+
+  def setup_save_mem_org_data
+    verb = 'POST'
+    endpoint = format('%s/org/users', resource[:grafana_api_path])
+    request_data = {
+      role: resource[:role],
+      loginOrEmail: resource[:user_name]
+    }
+    if exists?
+      verb = 'PATCH'
+      endpoint = format('%s/org/users/%s', resource[:grafana_api_path], @user[:id])
+    end
+    [verb, endpoint, request_data]
+  end
+
+  def save_membership_organization
+    set_current_organization
+    response = send_request(*setup_save_mem_org_data)
+    raise_on_error(response.code, format('Failed to update membership %s, (HTTP response: %s/%s)', resource, response.code, response.body))
+  end
+
+  def create
+    save_membership
+  end
+
+  def setup_destroy_data
+    if resource[:membership_type] == :organization
+      endpoint = format('%s/org/users/%s', resource[:grafana_api_path], @user[:id])
+    else # team
+      team unless @team
+      endpoint = format('%s/teams/%s/members/%s', resource[:grafana_api_path], @team[:id], @user[:id])
+    end
+    ['DELETE', endpoint]
+  end
+
+  def destroy_team_membership
+    return unless user && organization && team
+
+    endpoint = format('%s/teams/%s/members/%s', resource[:grafana_api_path], @team[:id], @user[:id])
+    response = send_request('DELETE', endpoint)
+    raise_on_error(response.code, format('Failed to delete team membership (HTTP response: %s/%s)', response.code, response.body))
+  end
+
+  def destroy_organization_membership
+    return unless user && organization
+
+    endpoint = format('%s/org/users/%s', resource[:grafana_api_path], @user[:id])
+    response = send_request('DELETE', endpoint)
+    raise_on_error(response.code, format('Failed to delete organization membership (HTTP response: %s/%s)', response.code, response.body))
+  end
+
+  def destroy
+    set_current_organization
+    resource[:membership_type] == :organization ? destroy_organization_membership : destroy_team_membership
+  end
+
+  def user_in_organization?
+    organization
+    return true if @user && @organization && @user[:organization] == @organization[:id]
+
+    false
+  end
+
+  def user_in_team?
+    team_member if team
+    return true if @user && @team && @team_member
+
+    false
+  end
+
+  def exists?
+    user
+    resource[:membership_type] == :organization ? user_in_organization? : user_in_team?
+  end
+end

--- a/lib/puppet/provider/grafana_organization/grafana.rb
+++ b/lib/puppet/provider/grafana_organization/grafana.rb
@@ -85,6 +85,11 @@ Puppet::Type.type(:grafana_organization).provide(:grafana, parent: Puppet::Provi
     if response.code != '200'
       raise format('Failed to delete organization %s (HTTP response: %s/%s)', resource[:name], response.code, response.body)
     end
+    # change back to default organization
+    response = send_request 'POST', format('%s/user/using/1', resource[:grafana_api_path])
+    unless response.code == '200'
+      raise format('Failed to switch to org %s (HTTP response: %s/%s)', fetch_organization[:id], response.code, response.body)
+    end
     self.organization = nil
   end
 

--- a/lib/puppet/provider/grafana_team/grafana.rb
+++ b/lib/puppet/provider/grafana_team/grafana.rb
@@ -45,9 +45,6 @@ Puppet::Type.type(:grafana_team).provide(:grafana, parent: Puppet::Provider::Gra
     org = resource[:organization] || resource[:target_name]
     key = org.is_a?(Numeric) || org.match(%r{/^[0-9]*$/}) ? :id : :name
     @organization = organizations.find { |x| x[key] == org }
-    # return @organization if @organization
-
-    # raise format('Unknown organization: %s', org)
   end
 
   def map_teams(teams)

--- a/lib/puppet/provider/grafana_team/grafana.rb
+++ b/lib/puppet/provider/grafana_team/grafana.rb
@@ -1,0 +1,238 @@
+# frozen_string_literal: true
+
+require 'json'
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'grafana'))
+
+Puppet::Type.type(:grafana_team).provide(:grafana, parent: Puppet::Provider::Grafana) do
+  desc 'Support for Grafana permissions'
+
+  defaultfor kernel: 'Linux'
+
+  def raise_on_error(code, message)
+    raise message if code != '200'
+  end
+
+  def parse_response(data)
+    JSON.parse(data)
+  rescue JSON::ParserError
+    raise format('Fail to parse response: %s', response.body)
+  end
+
+  def map_organizations(ids)
+    ids.map do |id|
+      response = send_request 'GET', format('%s/orgs/%s', resource[:grafana_api_path], id)
+      raise_on_error(response.code, format('Failed to retrieve organization %d (HTTP response: %s/%s)', id, response.code, response.body))
+
+      organization = parse_response(response.body)
+      {
+        id: organization['id'],
+        name: organization['name']
+      }
+    end
+  end
+
+  def organizations
+    response = send_request('GET', format('%s/orgs', resource[:grafana_api_path]))
+    raise_on_error(response.code, format('Fail to retrieve organizations (HTTP response: %s/%s)', response.code, response.body))
+    organizations = JSON.parse(response.body)
+    map_organizations(organizations.map { |x| x['id'] })
+  end
+
+  def organization
+    return @organization if @organization
+
+    org = resource[:organization] || resource[:target_name]
+    key = org.is_a?(Numeric) || org.match(%r{/^[0-9]*$/}) ? :id : :name
+    @organization = organizations.find { |x| x[key] == org }
+    # return @organization if @organization
+
+    # raise format('Unknown organization: %s', org)
+  end
+
+  def map_teams(teams)
+    teams['teams'].map do |team|
+      {
+        id: team['id'],
+        name: team['name'],
+        organization: team['orgId'],
+        membercount: team['membercount'],
+        permission: team['permission'],
+        email: team['email']
+      }
+    end
+  end
+
+  def teams
+    return [] unless organization
+
+    set_current_organization
+    response = send_request('GET', format('%s/teams/search', resource[:grafana_api_path]))
+    raise_on_error(response.code, format('Fail to retrieve teams (HTTP response: %s/%s)', response.code, response.body))
+    teams = parse_response(response.body)
+    map_teams(teams)
+  end
+
+  def team
+    @team ||= teams.find { |x| x[:name] == resource[:name] }
+  end
+
+  def map_preferences(preferences)
+    {
+      theme: preferences['theme'],
+      home_dashboard: preferences['homeDashboardId'],
+      timezone: preferences['timezone']
+    }
+  end
+
+  def preferences
+    team unless @team
+    return if @preferences
+
+    response = send_request('GET', format('%s/teams/%s/preferences', resource[:grafana_api_path], @team[:id]))
+    raise_on_error(response.code, format('Fail to retrieve teams (HTTP response: %s/%s)', response.code, response.body))
+    preferences = parse_response(response.body)
+    @preferences = map_preferences(preferences)
+  end
+
+  def setup_save_preferences_data
+    endpoint = format('%s/teams/%s/preferences', resource[:grafana_api_path], @team[:id])
+    dash = get_dashboard(resource[:home_dashboard])
+    request_data = {
+      theme: resource[:theme],
+      homeDashboardId: dash[:id],
+      timezone: resource[:timezone]
+    }
+    ['PUT', endpoint, request_data]
+  end
+
+  def save_preferences
+    team unless @team
+    set_current_organization
+    setup_save_preferences_data
+    response = send_request(*setup_save_preferences_data)
+    # TODO: Raise on error?
+    return if response.code == '200' || response.code == '412'
+
+    raise format('Failed to update team %s, (HTTP response: %s/%s)', resource, response.code, response.body)
+  end
+
+  def set_current_organization
+    response = send_request 'POST', format('%s/user/using/%s', resource[:grafana_api_path], organization[:id])
+    return if response.code == '200'
+
+    raise format('Failed to switch to org %s (HTTP response: %s/%s)', organization[:id], response.code, response.body)
+  end
+
+  def home_dashboard
+    preferences unless @preferences
+    dash = get_dashboard(@preferences[:home_dashboard])
+    return dash[:name] if dash
+
+    nil
+  end
+
+  def home_dashboard=(value)
+
+
+    resource[:home_dashboard] = value
+    save_preferences
+  end
+
+  def setup_search_path(ident)
+    if ident.is_a?(Numeric) || ident.match(%r{/^[0-9]*$/})
+      {
+        dashboardIds: ident,
+        type: 'dash-db'
+      }
+    else
+      {
+        query: ident,
+        type: 'dash-db'
+      }
+    end
+  end
+
+  def get_dashboard(ident)
+    set_current_organization
+    return { id: 0, name: 'Default' } if ident == 0 # rubocop:disable Style/NumericPredicate
+
+    search_path = setup_search_path(ident)
+    response = send_request('GET', format('%s/search', resource[:grafana_api_path]), nil, search_path)
+    raise_on_error(response.code, format('Fail to retrieve dashboars (HTTP response: %s/%s)', response.code, response.body))
+
+    dashboard = parse_response(response.body)
+    format_dashboard(dashboard)
+  end
+
+  def format_dashboard(dashboard)
+    return { id: 0, name: 'Default' } unless dashboard.first
+
+    {
+      id: dashboard.first['id'],
+      name: dashboard.first['title']
+    }
+  end
+
+  def theme
+    preferences unless @preferences
+    return @preferences[:theme] if @preferences
+
+    nil
+  end
+
+  def theme=(value)
+    resource[:theme] = value
+    save_preferences
+  end
+
+  def timezone
+    preferences unless @preferences
+    return @preferences[:timezone] if @preferences
+
+    nil
+  end
+
+  def timezone=(value)
+    resource[:timezone] = value
+    save_preferences
+  end
+
+  def setup_save_team_data
+    verb = 'POST'
+    endpoint = format('%s/teams', resource[:grafana_api_path])
+    request_data = { name: resource[:name], email: resource[:email] }
+    if exists?
+      verb = 'PUT'
+      endpoint = format('%s/teams/%s', resource[:grafana_api_path], @team[:id])
+    end
+    [verb, endpoint, request_data]
+  end
+
+  def save_team
+    set_current_organization
+    response = send_request(*setup_save_team_data)
+    raise_on_error(response.code, format('Failed to update team %s, (HTTP response: %s/%s)', resource, response.code, response.body))
+  end
+
+  def create
+    save_team
+    save_preferences
+  end
+
+  def destroy
+    return unless team
+
+    response = send_request('DELETE', format('%s/teams/%s', resource[:grafana_api_path], @team[:id]))
+    return unless response.code != '200'
+
+    raise Puppet::Error, format('Failed to delete team %s (HTTP response: %s/%s)', resource, response.code, response.body)
+  end
+
+  def exists?
+    team
+    return true if @team && @team[:name] == resource[:name]
+
+    false
+  end
+end

--- a/lib/puppet/provider/grafana_team/grafana.rb
+++ b/lib/puppet/provider/grafana_team/grafana.rb
@@ -130,8 +130,6 @@ Puppet::Type.type(:grafana_team).provide(:grafana, parent: Puppet::Provider::Gra
   end
 
   def home_dashboard=(value)
-
-
     resource[:home_dashboard] = value
     save_preferences
   end

--- a/lib/puppet/type/grafana_dashboard_permission.rb
+++ b/lib/puppet/type/grafana_dashboard_permission.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+Puppet::Type.newtype(:grafana_dashboard_permission) do
+  @doc = 'Manage dashboard permissions in Grafana'
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'The name of the permission.'
+  end
+
+  newparam(:user) do
+    desc 'User to add the permission for'
+
+    validate do |value|
+      raise ArgumentError, 'Only user or team can be set, not both' if value && @resource[:team]
+    end
+  end
+
+  newparam(:team) do
+    desc 'Team to add the permission for'
+
+    validate do |value|
+      raise ArgumentError, 'Only user or team can be set, not both' if value && @resource[:user]
+    end
+  end
+
+  newparam(:dashboard) do
+    desc 'Dashboard to modify permissions for'
+  end
+
+  newparam(:organization) do
+    desc 'The name of the organization to add permission for'
+    defaultto 'Main Org.'
+  end
+
+  newparam(:grafana_api_path) do
+    desc 'The absolute path to the API endpoint'
+    defaultto '/api'
+
+    validate do |value|
+      raise ArgumentError, format('%s is not a valid API path', value) unless value =~ %r{^/.*/?api$}
+    end
+  end
+
+  newparam(:grafana_url) do
+    desc 'The URL of the Grafana server'
+    defaultto ''
+
+    validate do |value|
+      raise ArgumentError, format('%s is not a valid URL', value) unless value =~ %r{^https?://}
+    end
+  end
+
+  newparam(:grafana_user) do
+    desc 'The username for the Grafana server'
+  end
+
+  newparam(:grafana_password) do
+    desc 'The password for the Grafana server'
+  end
+
+  newproperty(:permission) do
+    desc 'The role to apply'
+    newvalues(:Admin, :Edit, :View)
+  end
+
+  autorequire(:service) do
+    'grafana-server'
+  end
+
+  autorequire(:grafana_organization) do
+    catalog.resources.select { |r| r.is_a?(Puppet::Type.type(:grafana_organization)) }
+  end
+
+  autorequire(:grafana_user) do
+    catalog.resources.select { |r| r.is_a?(Puppet::Type.type(:grafana_user)) }
+  end
+
+  autorequire(:grafana_team) do
+    catalog.resources.select { |r| r.is_a?(Puppet::Type.type(:grafana_team)) }
+  end
+end

--- a/lib/puppet/type/grafana_dashboard_permission.rb
+++ b/lib/puppet/type/grafana_dashboard_permission.rb
@@ -80,4 +80,8 @@ Puppet::Type.newtype(:grafana_dashboard_permission) do
   autorequire(:grafana_team) do
     catalog.resources.select { |r| r.is_a?(Puppet::Type.type(:grafana_team)) }
   end
+
+  autorequire(:grafana_dashboard) do
+    catalog.resources.select { |r| r.is_a?(Puppet::Type.type(:grafana_dashboard)) }
+  end
 end

--- a/lib/puppet/type/grafana_membership.rb
+++ b/lib/puppet/type/grafana_membership.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+Puppet::Type.newtype(:grafana_membership) do
+  @doc = 'Manage resource memberships in Grafana'
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'The name of the membership.'
+  end
+
+  newparam(:user_name) do
+    desc 'The name of the user to add membership for'
+  end
+
+  newparam(:target_name) do
+    desc 'The name of the target to add membership for'
+  end
+
+  newparam(:organization) do
+    desc 'The name of the organization to add membership for (team only)'
+    defaultto 'Main Org.'
+  end
+
+  newparam(:grafana_api_path) do
+    desc 'The absolute path to the API endpoint'
+    defaultto '/api'
+
+    validate do |value|
+      raise ArgumentError, format('%s is not a valid API path', value) unless value =~ %r{^/.*/?api$}
+    end
+  end
+
+  newparam(:grafana_url) do
+    desc 'The URL of the Grafana server'
+    defaultto ''
+
+    validate do |value|
+      raise ArgumentError, format('%s is not a valid URL', value) unless value =~ %r{^https?://}
+    end
+  end
+
+  newparam(:grafana_user) do
+    desc 'The username for the Grafana server'
+  end
+
+  newparam(:grafana_password) do
+    desc 'The password for the Grafana server'
+  end
+
+  newparam(:membership_type) do
+    desc 'The underlying type of the membership (organization, team)'
+    newvalues(:organization, :team)
+  end
+
+  newproperty(:role) do
+    desc 'The role to apply to the membership (Admin, Editor, Viewer)'
+    newvalues(:Admin, :Editor, :Viewer)
+  end
+
+  autorequire(:service) do
+    'grafana-server'
+  end
+
+  autorequire(:grafana_organization) do
+    catalog.resources.select { |r| r.is_a?(Puppet::Type.type(:grafana_organization)) }
+  end
+
+  autorequire(:grafana_team) do
+    catalog.resources.select { |r| r.is_a?(Puppet::Type.type(:grafana_team)) }
+  end
+
+  autorequire(:grafana_membership) do
+    catalog.resources.select { |r| r.is_a?(Puppet::Type.type(:grafana_membership)) && r['membership_type'] == :organization } if self[:membership_type] == :team
+  end
+end

--- a/lib/puppet/type/grafana_organization.rb
+++ b/lib/puppet/type/grafana_organization.rb
@@ -1,13 +1,14 @@
 Puppet::Type.newtype(:grafana_organization) do
   @doc = 'Manage organizations in Grafana'
 
-  ensurable do
-    defaultvalues
-    defaultto :present
-  end
+  ensurable
 
   newparam(:name, namevar: true) do
     desc 'The name of the organization.'
+
+    validate do |value|
+      raise ArgumentError, format('Unable to modify default organization') if value == 'Main Org.'
+    end
   end
 
   newparam(:grafana_api_path) do

--- a/lib/puppet/type/grafana_team.rb
+++ b/lib/puppet/type/grafana_team.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+Puppet::Type.newtype(:grafana_team) do
+  @doc = 'Manage teams in Grafana'
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'The name of the team'
+  end
+
+  newparam(:grafana_api_path) do
+    desc 'The absolute path to the API endpoint'
+    defaultto '/api'
+
+    validate do |value|
+      unless value =~ %r{^/.*/?api$}
+        raise ArgumentError, format('%s is not a valid API path', value)
+      end
+    end
+  end
+
+  newparam(:grafana_url) do
+    desc 'The URL of the Grafana server'
+    defaultto ''
+
+    validate do |value|
+      unless value =~ %r{^https?://}
+        raise ArgumentError, format('%s is not a valid URL', value)
+      end
+    end
+  end
+
+  newparam(:grafana_user) do
+    desc 'The username for the Grafana server'
+  end
+
+  newparam(:grafana_password) do
+    desc 'The password for the Grafana server'
+  end
+
+  newparam(:organization) do
+    desc 'The organization the team belongs to'
+  end
+
+  newparam(:email) do
+    desc 'The email for the team'
+    defaultto ''
+  end
+
+  newproperty(:home_dashboard) do
+    desc 'The id or name of the home dashboard'
+  end
+
+  newproperty(:theme) do
+    desc 'The theme to use for the team'
+  end
+
+  newproperty(:timezone) do
+    desc 'The timezone to use for the team'
+  end
+
+  autorequire(:service) do
+    'grafana-server'
+  end
+
+  autorequire(:grafana_dashboard) do
+    catalog.resources.select { |r| r.is_a?(Puppet::Type.type(:grafana_dashboard)) }
+  end
+
+  autorequire(:grafana_organization) do
+    catalog.resources.select { |r| r.is_a?(Puppet::Type.type(:grafana_organization)) }
+  end
+end

--- a/spec/grafana_dashboard_permission_type_spec.rb
+++ b/spec/grafana_dashboard_permission_type_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:grafana_dashboard_permission) do
+  let(:gpermission) do
+    described_class.new(
+      title: 'foo_title',
+      grafana_url: 'http://example.com/',
+      grafana_api_path: '/api',
+      user: 'foo_user',
+      dashboard: 'foo_dashboard',
+      permission: 'View',
+      ensure: :present
+    )
+  end
+
+  context 'when setting parameters' do
+    it "fails if grafana_url isn't HTTP-based" do
+      expect do
+        described_class.new title: 'foo_title', name: 'foo', grafana_url: 'example.com', ensure: :present
+      end.to raise_error(Puppet::Error, %r{not a valid URL})
+    end
+
+    it "fails if grafana_api_path isn't properly formed" do
+      expect do
+        described_class.new title: 'foo_title', grafana_url: 'http://example.com', grafana_api_path: '/invalidpath', ensure: :present
+      end.to raise_error(Puppet::Error, %r{not a valid API path})
+    end
+
+    it 'fails if both user and team set' do
+      expect do
+        described_class.new title: 'foo title', user: 'foo_user', team: 'foo_team'
+      end.to raise_error(Puppet::Error, %r{Only user or team can be set, not both})
+    end
+
+    # rubocop:disable RSpec/MultipleExpectations
+    it 'accepts valid parameters' do
+      expect(gpermission[:user]).to eq('foo_user')
+      expect(gpermission[:grafana_api_path]).to eq('/api')
+      expect(gpermission[:grafana_url]).to eq('http://example.com/')
+      expect(gpermission[:dashboard]).to eq('foo_dashboard')
+    end
+    # rubocop:enable RSpec/MultipleExpectations
+
+    it 'autorequires the grafana-server for proper ordering' do
+      catalog = Puppet::Resource::Catalog.new
+      service = Puppet::Type.type(:service).new(name: 'grafana-server')
+      catalog.add_resource service
+      catalog.add_resource gpermission
+
+      relationship = gpermission.autorequire.find do |rel|
+        (rel.source.to_s == 'Service[grafana-server]') && (rel.target.to_s == gpermission.to_s)
+      end
+      expect(relationship).to be_a Puppet::Relationship
+    end
+
+    it 'does not autorequire the service it is not managed' do
+      catalog = Puppet::Resource::Catalog.new
+      catalog.add_resource gpermission
+      expect(gpermission.autorequire).to be_empty
+    end
+  end
+end

--- a/spec/grafana_membership_type_spec.rb
+++ b/spec/grafana_membership_type_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:grafana_membership) do
+  let(:gmembership) do
+    described_class.new(
+      title: 'foo_title',
+      user_name: 'foo_user',
+      target_name: 'foo_target',
+      grafana_url: 'http://example.com/',
+      grafana_api_path: '/api',
+      membership_type: 'organization',
+      role: 'Viewer',
+      ensure: :present
+    )
+  end
+
+  context 'when setting parameters' do
+    it "fails if grafana_url isn't HTTP-based" do
+      expect do
+        described_class.new title: 'foo_title', name: 'foo', grafana_url: 'example.com', ensure: :present
+      end.to raise_error(Puppet::Error, %r{not a valid URL})
+    end
+
+    it "fails if grafana_api_path isn't properly formed" do
+      expect do
+        described_class.new title: 'foo_title', grafana_url: 'http://example.com', grafana_api_path: '/invalidpath', ensure: :present
+      end.to raise_error(Puppet::Error, %r{not a valid API path})
+    end
+
+    it 'fails if membership type not valid' do
+      expect do
+        described_class.new title: 'foo title', membership_type: 'foo'
+      end.to raise_error(Puppet::Error, %r{Invalid value "foo"})
+    end
+
+    # rubocop:disable RSpec/MultipleExpectations
+    it 'accepts valid parameters' do
+      expect(gmembership[:user_name]).to eq('foo_user')
+      expect(gmembership[:target_name]).to eq('foo_target')
+      expect(gmembership[:grafana_api_path]).to eq('/api')
+      expect(gmembership[:grafana_url]).to eq('http://example.com/')
+      expect(gmembership[:membership_type]).to eq(:organization)
+    end
+    # rubocop:enable RSpec/MultipleExpectations
+
+    it 'autorequires the grafana-server for proper ordering' do
+      catalog = Puppet::Resource::Catalog.new
+      service = Puppet::Type.type(:service).new(name: 'grafana-server')
+      catalog.add_resource service
+      catalog.add_resource gmembership
+
+      relationship = gmembership.autorequire.find do |rel|
+        (rel.source.to_s == 'Service[grafana-server]') && (rel.target.to_s == gmembership.to_s)
+      end
+      expect(relationship).to be_a Puppet::Relationship
+    end
+
+    it 'does not autorequire the service it is not managed' do
+      catalog = Puppet::Resource::Catalog.new
+      catalog.add_resource gmembership
+      expect(gmembership.autorequire).to be_empty
+    end
+  end
+end

--- a/spec/unit/puppet/type/grafana_team_type_spec.rb
+++ b/spec/unit/puppet/type/grafana_team_type_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:grafana_team) do
+  let(:gteam) do
+    described_class.new(
+      name: 'foo',
+      grafana_url: 'http://example.com',
+      grafana_user: 'admin',
+      grafana_password: 'admin',
+      home_dashboard: 'foo_dashboard',
+      organization: 'foo_organization'
+    )
+  end
+
+  context 'when setting parameters' do
+    it "fails if grafana_url isn't HTTP-based" do
+      expect do
+        described_class.new name: 'foo', grafana_url: 'example.com', content: '{}', ensure: :present
+      end.to raise_error(Puppet::Error, %r{not a valid URL})
+    end
+
+    # rubocop:disable RSpec/MultipleExpectations
+    it 'accepts valid parameters' do
+      expect(gteam[:name]).to eq('foo')
+      expect(gteam[:grafana_user]).to eq('admin')
+      expect(gteam[:grafana_password]).to eq('admin')
+      expect(gteam[:grafana_url]).to eq('http://example.com')
+      expect(gteam[:home_dashboard]).to eq('foo_dashboard')
+      expect(gteam[:organization]).to eq('foo_organization')
+    end
+    # rubocop:enable RSpec/MultipleExpectations
+
+    it 'autorequires the grafana-server for proper ordering' do
+      catalog = Puppet::Resource::Catalog.new
+      service = Puppet::Type.type(:service).new(name: 'grafana-server')
+      catalog.add_resource service
+      catalog.add_resource gteam
+
+      relationship = gteam.autorequire.find do |rel|
+        (rel.source.to_s == 'Service[grafana-server]') && (rel.target.to_s == gteam.to_s)
+      end
+      expect(relationship).to be_a Puppet::Relationship
+    end
+
+    it 'does not autorequire the service it is not managed' do
+      catalog = Puppet::Resource::Catalog.new
+      catalog.add_resource gteam
+      expect(gteam.autorequire).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
This pull request addresses the following concerns:

teams

Currently there is no support in this module for managing teams within an organization. Have added this type. Allows the home dashboard for team to be set / updated also.

organizations

To bring orgs in line with other resources - have updated this type so that orgs can be deleted. Couple of caveats to ensure predictability - default org "mainOrg." cannot be modified and if an organization is deleted, the orgnanization in use is returned to the default org.

dashboard permissions

I see another merge just now where the folder permissions were set on the folder itself. I am open to redoing the permissions as properties on a dashboard but I feel having permissions as a different type is easier to use and saves having to use hashes.

Able to set permissions on a dashboard for either a user or a team. Once permissions are set, the default permissions on a dashboard are removed. Otherwise this defeats the point of setting permissions per team/user.

memberships

This is the concept of a user belonging to an organization or a team.

autorequires

Due to the reliance on some of these types on other types being defined prior, these new types have autorequires to ensure ordering is done properly without the end user having to do it. As long as the resources specified in the parameters are present - it will work.