### PR TITLE
Fix `grafana_user` `password` idempotency

### DIFF
--- a/lib/puppet/type/grafana_user.rb
+++ b/lib/puppet/type/grafana_user.rb
@@ -43,6 +43,9 @@ Puppet::Type.newtype(:grafana_user) do
 
   newproperty(:password) do
     desc 'The password for the user'
+    def insync?(_is)
+      provider.check_password
+    end
   end
 
   newproperty(:email) do

--- a/spec/acceptance/grafana_user_spec.rb
+++ b/spec/acceptance/grafana_user_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper_acceptance'
+
+describe 'grafana_user' do
+  context 'setup grafana server' do
+    it 'runs successfully' do
+      pp = <<-EOS
+      class { 'grafana':
+        cfg => {
+          security => {
+            admin_user     => 'admin',
+            admin_password => 'admin'
+          }
+        }
+      }
+      EOS
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+  end
+  it 'runs successfully' do
+    pp = <<-EOS
+
+    grafana_user { 'user1':
+      grafana_url       => 'http://localhost:3000',
+      grafana_user      => 'admin',
+      grafana_password  => 'admin',
+      full_name         => 'John Doe',
+      password          => 'Us3r5ecret',
+      email             => 'john@example.com',
+    }
+    EOS
+    apply_manifest(pp, catch_failures: true)
+    apply_manifest(pp, catch_changes: true)
+  end
+end


### PR DESCRIPTION
This PR fixes the issue that on each puppet run the user password will be set.
As the grafana api does not provide any feature for that we try to connect as that user if login works we suppress the password change.

Fixes #104 