### PR TITLE
Support installing grafana plugins from urls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN bundle install --without system_tests development release --path=${BUNDLE_PA
 
 COPY . .
 
+ENV LANG=C.UTF-8
 RUN bundle install
 RUN bundle exec rake release_checks
 

--- a/README.md
+++ b/README.md
@@ -859,6 +859,15 @@ grafana_plugin { 'grafana-simple-json-datasource':
 }
 ```
 
+It is also possible to specify a custom plugin url to install a plugin. This will use the --pluginUrl option for plugin installation with grafana_cli.
+
+```puppet
+grafana_plugin { 'grafana-example-custom-plugin':
+  ensure    => present,
+  plugin_url => 'https://github.com/example/example-custom-plugin/zipball/v1.0.0'
+}
+```
+
 ##### `grafana_folder`
 
 Creates and manages Grafana folders via the API.

--- a/lib/puppet/provider/grafana_plugin/grafana_cli.rb
+++ b/lib/puppet/provider/grafana_plugin/grafana_cli.rb
@@ -48,6 +48,9 @@ Puppet::Type.type(:grafana_plugin).provide(:grafana_cli) do
     if resource[:repo]
       repo = "--repo #{resource[:repo]}"
       grafana_cli(repo, 'plugins', 'install', resource[:name])
+    elsif resource[:plugin_url]
+      plugin_url = "--pluginUrl #{resource[:plugin_url]}"
+      grafana_cli(plugin_url, 'plugins', 'install', resource[:name])
     else
       grafana_cli('plugins', 'install', resource[:name])
     end

--- a/lib/puppet/type/grafana_plugin.rb
+++ b/lib/puppet/type/grafana_plugin.rb
@@ -14,7 +14,7 @@ manages grafana plugins
 @example Install a grafana plugin from a plugin url
  grafana_plugin { 'grafana-simple-json-datasource':
    ensure => present,
-   plugin_url   => 'https://github.com/example/example-custom-plugin/zipball/v1.0.0'
+   plugin_url => 'https://github.com/example/example-custom-plugin/zipball/v1.0.0'
  }
 
 @example Uninstall a grafana plugin

--- a/lib/puppet/type/grafana_plugin.rb
+++ b/lib/puppet/type/grafana_plugin.rb
@@ -11,6 +11,12 @@ manages grafana plugins
    repo   => 'https://nexus.company.com/grafana/plugins',
  }
 
+@example Install a grafana plugin from a plugin url
+ grafana_plugin { 'grafana-simple-json-datasource':
+   ensure => present,
+   plugin_url   => 'https://github.com/example/example-custom-plugin/zipball/v1.0.0'
+ }
+
 @example Uninstall a grafana plugin
  grafana_plugin { 'grafana-simple-json-datasource':
    ensure => absent,
@@ -37,11 +43,20 @@ DESC
 
   newparam(:repo) do
     desc 'The URL of an internal plugin server'
-
     validate do |value|
       unless value =~ %r{^https?://}
         raise ArgumentError, format('%s is not a valid URL', value)
       end
     end
   end
+
+  newparam(:plugin_url) do
+    desc 'Full url to the plugin zip file'
+    validate do |value|
+      unless value =~ %r{^https?://}
+        raise ArgumentError, format('%s is not a valid URL', value)
+      end
+    end
+  end
+
 end

--- a/lib/puppet/type/grafana_plugin.rb
+++ b/lib/puppet/type/grafana_plugin.rb
@@ -12,7 +12,7 @@ manages grafana plugins
  }
 
 @example Install a grafana plugin from a plugin url
- grafana_plugin { 'grafana-simple-json-datasource':
+ grafana_plugin { 'grafana-example-custom-plugin':
    ensure => present,
    plugin_url => 'https://github.com/example/example-custom-plugin/zipball/v1.0.0'
  }

--- a/spec/acceptance/grafana_plugin_spec.rb
+++ b/spec/acceptance/grafana_plugin_spec.rb
@@ -40,6 +40,27 @@ describe 'grafana_plugin' do
     end
   end
 
+  context 'create plugin resource with url' do
+    it 'runs successfully' do
+      pp = <<-EOS
+      class { 'grafana':}
+      include grafana::validator
+      grafana_plugin { 'grafana-example-custom-plugin':
+        ensure => present,
+        plugin_url => 'https://github.com/example/example-custom-plugin/zipball/v1.0.0',
+      }
+      EOS
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    it 'has the plugin' do
+      shell('grafana-cli plugins ls') do |r|
+        expect(r.stdout).to match(%r{grafana-example-custom-plugin})
+      end
+    end
+  end
+
   context 'destroy plugin resource' do
     it 'runs successfully' do
       pp = <<-EOS

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -62,7 +62,8 @@ describe 'grafana' do
             {
               'grafana-wizzle' => { 'ensure' => 'present' },
               'grafana-woozle' => { 'ensure' => 'absent' },
-              'grafana-plugin' => { 'ensure' => 'present', 'repo' => 'https://nexus.company.com/grafana/plugins' }
+              'grafana-plugin' => { 'ensure' => 'present', 'repo' => 'https://nexus.company.com/grafana/plugins' },
+              'grafana-plugin-url' => { 'ensure' => 'present', 'plugin_url' => 'https://github.com/example/example-custom-plugin/zipball/v1.0.0' }
             }
           }
         end
@@ -70,9 +71,14 @@ describe 'grafana' do
         it { is_expected.to contain_grafana_plugin('grafana-wizzle').with(ensure: 'present') }
         it { is_expected.to contain_grafana_plugin('grafana-woozle').with(ensure: 'absent').that_notifies('Class[grafana::service]') }
 
-        describe 'install plugin with pluginurl' do
+        describe 'install plugin with plugin repo' do
           it { is_expected.to contain_grafana_plugin('grafana-plugin').with(ensure: 'present', repo: 'https://nexus.company.com/grafana/plugins') }
         end
+
+        describe 'install plugin with plugin url' do
+          it { is_expected.to contain_grafana_plugin('grafana-plugin-url').with(ensure: 'present', plugin_url: 'https://github.com/example/example-custom-plugin/zipball/v1.0.0') }
+        end
+
       end
 
       context 'with parameter install_method is set to repo' do

--- a/spec/unit/puppet/provider/grafana_plugin/grafana_cli_spec.rb
+++ b/spec/unit/puppet/provider/grafana_plugin/grafana_cli_spec.rb
@@ -71,4 +71,21 @@ Restart grafana after installing plugins . <service grafana-server restart>
       expect(provider).to have_received(:grafana_cli).with('--repo https://nexus.company.com/grafana/plugins', 'plugins', 'install', 'grafana-plugin')
     end
   end
+
+  describe 'create with plugin url' do
+    let(:resource) do
+      Puppet::Type::Grafana_plugin.new(
+        name: 'grafana-plugin',
+        plugin_url: 'https://github.com/example/example-custom-plugin/zipball/v1.0.0'
+      )
+    end
+
+    it '#create with plugin url' do
+      allow(provider).to receive(:grafana_cli)
+      provider.create
+      expect(provider).to have_received(:grafana_cli).with('--pluginUrl https://github.com/example/example-custom-plugin/zipball/v1.0.0', 'plugins', 'install', 'grafana-plugin')
+    end
+  end
+
+
 end

--- a/spec/unit/puppet/type/grafana_plugin_spec.rb
+++ b/spec/unit/puppet/type/grafana_plugin_spec.rb
@@ -18,4 +18,9 @@ describe Puppet::Type.type(:grafana_plugin) do
     plugin[:repo] = 'https://nexus.company.com/grafana/plugins'
     expect(plugin[:repo]).to eq('https://nexus.company.com/grafana/plugins')
   end
+  it 'accepts a plugin url' do
+    plugin[:plugin_url] = 'https://github.com/example/example-custom-plugin/zipball/v1.0.0'
+    expect(plugin[:plugin_url]).to eq('https://github.com/example/example-custom-plugin/zipball/v1.0.0')
+  end
+
 end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This PR enables installing plugins via the "--pluginUrl" flag available in the grafana cli by adding an optional parameter to the grafana_plugin defined type. This was implemented based on the existing "repo" parameter that is already supported.

#### This Pull Request (PR) fixes the following issues
Fixes #173 

