### PR TITLE
Don't manage dashboard path when puppetsource is not set

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -132,14 +132,16 @@ class grafana::config {
             }
           }
 
-          file { $options['path'] :
-            ensure  => directory,
-            owner   => 'grafana',
-            group   => 'grafana',
-            mode    => '0750',
-            recurse => true,
-            purge   => true,
-            source  => $options['puppetsource'],
+          if $options['puppetsource'] {
+            file { $options['path'] :
+              ensure  => directory,
+              owner   => 'grafana',
+              group   => 'grafana',
+              mode    => '0750',
+              recurse => true,
+              purge   => true,
+              source  => $options['puppetsource'],
+            }
           }
         }
       }

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -378,6 +378,67 @@ describe 'grafana' do
         end
       end
 
+      context 'provisioning_dashboards defined' do
+        let(:params) do
+          {
+            version: '6.0.0',
+            provisioning_dashboards: {
+              apiVersion: 1,
+              providers: [
+                {
+                  name: 'default',
+                  orgId: 1,
+                  folder: '',
+                  type: 'file',
+                  disableDeletion: true,
+                  options: {
+                    path: '/var/lib/grafana/dashboards',
+                    puppetsource: 'puppet:///modules/my_custom_module/dashboards'
+                  }
+                }
+              ]
+            }
+          }
+        end
+
+        it do
+          is_expected.to contain_file('/var/lib/grafana/dashboards').with(
+            ensure: 'directory',
+            owner: 'grafana',
+            group: 'grafana',
+            mode: '0750',
+            recurse: true,
+            purge: true,
+            source: 'puppet:///modules/my_custom_module/dashboards'
+          )
+        end
+
+        context 'without puppetsource defined' do
+          let(:params) do
+            {
+              version: '6.0.0',
+              provisioning_dashboards: {
+                apiVersion: 1,
+                providers: [
+                  {
+                    name: 'default',
+                    orgId: 1,
+                    folder: '',
+                    type: 'file',
+                    disableDeletion: true,
+                    options: {
+                      path: '/var/lib/grafana/dashboards'
+                    }
+                  }
+                ]
+              }
+            }
+          end
+
+          it { is_expected.not_to contain_file('/var/lib/grafana/dashboards') }
+        end
+      end
+
       context 'sysconfig environment variables' do
         let(:params) do
           {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
Handle case where `puppetsource` is not defined. The way I use this is I deploy my dashboards with a massive git repo and define lots of provisioning dashboards based on sub directories in that git repo by omitting `puppetsource`.

This is a continuation on #187 