### PR TITLE
Ensure all API types have grafana_conn_validator autorequires

### DIFF
--- a/lib/puppet/type/grafana_dashboard_permission.rb
+++ b/lib/puppet/type/grafana_dashboard_permission.rb
@@ -84,4 +84,8 @@ Puppet::Type.newtype(:grafana_dashboard_permission) do
   autorequire(:grafana_dashboard) do
     catalog.resources.select { |r| r.is_a?(Puppet::Type.type(:grafana_dashboard)) }
   end
+
+  autorequire(:grafana_conn_validator) do
+    'grafana'
+  end
 end

--- a/lib/puppet/type/grafana_membership.rb
+++ b/lib/puppet/type/grafana_membership.rb
@@ -73,4 +73,8 @@ Puppet::Type.newtype(:grafana_membership) do
   autorequire(:grafana_membership) do
     catalog.resources.select { |r| r.is_a?(Puppet::Type.type(:grafana_membership)) && r['membership_type'] == :organization } if self[:membership_type] == :team
   end
+
+  autorequire(:grafana_conn_validator) do
+    'grafana'
+  end
 end

--- a/lib/puppet/type/grafana_team.rb
+++ b/lib/puppet/type/grafana_team.rb
@@ -73,4 +73,8 @@ Puppet::Type.newtype(:grafana_team) do
   autorequire(:grafana_organization) do
     catalog.resources.select { |r| r.is_a?(Puppet::Type.type(:grafana_organization)) }
   end
+
+  autorequire(:grafana_conn_validator) do
+    'grafana'
+  end
 end

--- a/spec/grafana_dashboard_permission_type_spec.rb
+++ b/spec/grafana_dashboard_permission_type_spec.rb
@@ -56,5 +56,17 @@ describe Puppet::Type.type(:grafana_dashboard_permission) do
       catalog.add_resource gpermission
       expect(gpermission.autorequire).to be_empty
     end
+
+    it 'autorequires grafana_conn_validator' do
+      catalog = Puppet::Resource::Catalog.new
+      validator = Puppet::Type.type(:grafana_conn_validator).new(name: 'grafana')
+      catalog.add_resource validator
+      catalog.add_resource gpermission
+
+      relationship = gpermission.autorequire.find do |rel|
+        (rel.source.to_s == 'Grafana_conn_validator[grafana]') && (rel.target.to_s == gpermission.to_s)
+      end
+      expect(relationship).to be_a Puppet::Relationship
+    end
   end
 end

--- a/spec/grafana_membership_type_spec.rb
+++ b/spec/grafana_membership_type_spec.rb
@@ -58,5 +58,17 @@ describe Puppet::Type.type(:grafana_membership) do
       catalog.add_resource gmembership
       expect(gmembership.autorequire).to be_empty
     end
+
+    it 'autorequires grafana_conn_validator' do
+      catalog = Puppet::Resource::Catalog.new
+      validator = Puppet::Type.type(:grafana_conn_validator).new(name: 'grafana')
+      catalog.add_resource validator
+      catalog.add_resource gmembership
+
+      relationship = gmembership.autorequire.find do |rel|
+        (rel.source.to_s == 'Grafana_conn_validator[grafana]') && (rel.target.to_s == gmembership.to_s)
+      end
+      expect(relationship).to be_a Puppet::Relationship
+    end
   end
 end

--- a/spec/unit/puppet/type/grafana_dashboard_type_spec.rb
+++ b/spec/unit/puppet/type/grafana_dashboard_type_spec.rb
@@ -57,5 +57,16 @@ describe Puppet::Type.type(:grafana_dashboard) do
       catalog.add_resource gdashboard
       expect(gdashboard.autorequire).to be_empty
     end
+    it 'autorequires grafana_conn_validator' do
+      catalog = Puppet::Resource::Catalog.new
+      validator = Puppet::Type.type(:grafana_conn_validator).new(name: 'grafana')
+      catalog.add_resource validator
+      catalog.add_resource gdashboard
+
+      relationship = gdashboard.autorequire.find do |rel|
+        (rel.source.to_s == 'Grafana_conn_validator[grafana]') && (rel.target.to_s == gdashboard.to_s)
+      end
+      expect(relationship).to be_a Puppet::Relationship
+    end
   end
 end

--- a/spec/unit/puppet/type/grafana_folder_type_spec.rb
+++ b/spec/unit/puppet/type/grafana_folder_type_spec.rb
@@ -50,5 +50,16 @@ describe Puppet::Type.type(:grafana_folder) do
       catalog.add_resource gfolder
       expect(gfolder.autorequire).to be_empty
     end
+    it 'autorequires grafana_conn_validator' do
+      catalog = Puppet::Resource::Catalog.new
+      validator = Puppet::Type.type(:grafana_conn_validator).new(name: 'grafana')
+      catalog.add_resource validator
+      catalog.add_resource gfolder
+
+      relationship = gfolder.autorequire.find do |rel|
+        (rel.source.to_s == 'Grafana_conn_validator[grafana]') && (rel.target.to_s == gfolder.to_s)
+      end
+      expect(relationship).to be_a Puppet::Relationship
+    end
   end
 end

--- a/spec/unit/puppet/type/grafana_organization_type_spec.rb
+++ b/spec/unit/puppet/type/grafana_organization_type_spec.rb
@@ -49,5 +49,17 @@ describe Puppet::Type.type(:grafana_organization) do
       catalog.add_resource gorganization
       expect(gorganization.autorequire).to be_empty
     end
+
+    it 'autorequires grafana_conn_validator' do
+      catalog = Puppet::Resource::Catalog.new
+      validator = Puppet::Type.type(:grafana_conn_validator).new(name: 'grafana')
+      catalog.add_resource validator
+      catalog.add_resource gorganization
+
+      relationship = gorganization.autorequire.find do |rel|
+        (rel.source.to_s == 'Grafana_conn_validator[grafana]') && (rel.target.to_s == gorganization.to_s)
+      end
+      expect(relationship).to be_a Puppet::Relationship
+    end
   end
 end

--- a/spec/unit/puppet/type/grafana_team_type_spec.rb
+++ b/spec/unit/puppet/type/grafana_team_type_spec.rb
@@ -45,5 +45,17 @@ describe Puppet::Type.type(:grafana_team) do
       catalog.add_resource gteam
       expect(gteam.autorequire).to be_empty
     end
+
+    it 'autorequires grafana_conn_validator' do
+      catalog = Puppet::Resource::Catalog.new
+      validator = Puppet::Type.type(:grafana_conn_validator).new(name: 'grafana')
+      catalog.add_resource validator
+      catalog.add_resource gteam
+
+      relationship = gteam.autorequire.find do |rel|
+        (rel.source.to_s == 'Grafana_conn_validator[grafana]') && (rel.target.to_s == gteam.to_s)
+      end
+      expect(relationship).to be_a Puppet::Relationship
+    end
   end
 end

--- a/spec/unit/puppet/type/grafana_user_type_spec.rb
+++ b/spec/unit/puppet/type/grafana_user_type_spec.rb
@@ -44,5 +44,16 @@ describe Puppet::Type.type(:grafana_user) do
       catalog.add_resource guser
       expect(guser.autorequire).to be_empty
     end
+    it 'autorequires grafana_conn_validator' do
+      catalog = Puppet::Resource::Catalog.new
+      validator = Puppet::Type.type(:grafana_conn_validator).new(name: 'grafana')
+      catalog.add_resource validator
+      catalog.add_resource guser
+
+      relationship = guser.autorequire.find do |rel|
+        (rel.source.to_s == 'Grafana_conn_validator[grafana]') && (rel.target.to_s == guser.to_s)
+      end
+      expect(relationship).to be_a Puppet::Relationship
+    end
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
Some newer API types did not get added with autorequires on Grafana_conn_validator so this gets those new types to have same autorequirement as other types to ensure the API is ready before executing API commands.

Add unit tests around grafana_conn_validator autorequires