### PR TITLE
Fix `puppet generate types`

### DIFF
--- a/lib/puppet/type/grafana_ldap_config.rb
+++ b/lib/puppet/type/grafana_ldap_config.rb
@@ -1,4 +1,5 @@
 require 'toml'
+require 'puppet/parameter/boolean'
 
 Puppet::Type.newtype(:grafana_ldap_config) do
   @doc = 'Manage Grafana LDAP configuration'


### PR DESCRIPTION
#### Pull Request (PR) description

When running puppet generate types, the following error is raised:

```
Notice: Generating Puppet resource types.
Error: Failed to load custom type 'grafana_ldap_config' from '/etc/puppetlabs/code/environments/production/modules/grafana/lib/puppet/type/grafana_ldap_config.rb': uninitialized constant Puppet::Parameter::Boolean
```

Adding this require statement fix this issue.

#### This Pull Request (PR) fixes the following issues
n/a