### PR TITLE
Fix types to work with 'puppet generate types'

### DIFF
--- a/lib/puppet/type/grafana_ldap_group_mapping.rb
+++ b/lib/puppet/type/grafana_ldap_group_mapping.rb
@@ -1,3 +1,5 @@
+require 'puppet/parameter/boolean'
+
 Puppet::Type.newtype(:grafana_ldap_group_mapping) do
   @doc = 'Map an LDAP group to a Grafana role.'
 

--- a/lib/puppet/type/grafana_ldap_server.rb
+++ b/lib/puppet/type/grafana_ldap_server.rb
@@ -1,3 +1,5 @@
+require 'puppet/parameter/boolean'
+
 Puppet::Type.newtype(:grafana_ldap_server) do
   @doc = 'Manage Grafana LDAP servers for LDAP authentication.'
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
Fix types to work with `puppet generate types`.  These are the errors being produced:

```
Jan 14 09:45:53 puppet0 r10k-postrun: #033[1;31mError: Failed to load custom type 'grafana_ldap_group_mapping' from '/etc/puppetlabs/code/environments/test_xdmod/modules/grafana/lib/puppet/type/grafana_ldap_group_mapping.rb': uninitialized constant Puppet::Parameter::Boolean#033[0m
Jan 14 09:45:54 puppet0 r10k-postrun: #033[1;31mError: Failed to load custom type 'grafana_ldap_server' from '/etc/puppetlabs/code/environments/test_xdmod/modules/grafana/lib/puppet/type/grafana_ldap_server.rb': uninitialized constant Puppet::Parameter::Boolean#033[0m
```