### PR TITLE
Allow grafana_team home dashboard to be scoped to a folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,8 @@ Organziation must exist if specified.
 
 `name` is optional if the name will differ from example_team above.
 
+`home_dashboard_folder` is optional. Sets the folder where home dashboard resides. Dashboard folder must exist.
+
 `home_dashboard` is optional. Sets the home dashboard for team. Dashboard must exist.
 
 `organization` is optional. Defaults to `Main org.`

--- a/lib/puppet/type/grafana_plugin.rb
+++ b/lib/puppet/type/grafana_plugin.rb
@@ -58,5 +58,4 @@ DESC
       end
     end
   end
-
 end

--- a/lib/puppet/type/grafana_team.rb
+++ b/lib/puppet/type/grafana_team.rb
@@ -49,6 +49,10 @@ Puppet::Type.newtype(:grafana_team) do
     defaultto ''
   end
 
+  newproperty(:home_dashboard_folder) do
+    desc 'The UID or name of the home dashboard folder'
+  end
+
   newproperty(:home_dashboard) do
     desc 'The id or name of the home dashboard'
     defaultto 'Default'

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -159,7 +159,6 @@ describe 'grafana class' do
         shell('yum -y downgrade grafana')
         # No manifest to apply here
       end
-
     end
 
     describe package('grafana') do

--- a/spec/acceptance/grafana_team_spec.rb
+++ b/spec/acceptance/grafana_team_spec.rb
@@ -58,12 +58,35 @@ describe 'grafana_team' do
         grafana_password => 'admin',
         content          => '{"uid": "zyx986bc"}',
       }
+      grafana_folder { 'example-folder':
+        ensure           => present,
+        uid              => 'example-folder',
+        grafana_url      => 'http://localhost:3000',
+        grafana_user     => 'admin',
+        grafana_password => 'admin',
+      }
+      -> grafana_dashboard { 'example-dashboard2':
+        ensure           => present,
+        grafana_url      => 'http://localhost:3000',
+        grafana_user     => 'admin',
+        grafana_password => 'admin',
+        content          => '{"uid": "niew0ahN"}',
+        folder           => 'example-folder',
+      }
       grafana_team { 'example-team':
         ensure           => present,
         grafana_url      => 'http://localhost:3000',
         grafana_user     => 'admin',
         grafana_password => 'admin',
         home_dashboard   => 'example-dashboard',
+      }
+      grafana_team { 'example-team2':
+        ensure                => present,
+        grafana_url           => 'http://localhost:3000',
+        grafana_user          => 'admin',
+        grafana_password      => 'admin',
+        home_dashboard_folder => 'example-folder',
+        home_dashboard        => 'example-dashboard2',
       }
       EOS
       apply_manifest(pp, catch_failures: true)
@@ -72,6 +95,13 @@ describe 'grafana_team' do
 
     it 'has updated the example team home dashboard' do
       shell('curl --user admin:admin http://localhost:3000/api/teams/1/preferences') do |f|
+        data = JSON.parse(f.stdout)
+        expect(data['homeDashboardId']).not_to eq(0)
+      end
+    end
+
+    it 'has updated the example team home dashboard with folder' do
+      shell('curl --user admin:admin http://localhost:3000/api/teams/2/preferences') do |f|
         data = JSON.parse(f.stdout)
         expect(data['homeDashboardId']).not_to eq(0)
       end
@@ -118,6 +148,12 @@ describe 'grafana_team' do
         grafana_user     => 'admin',
         grafana_password => 'admin',
       }
+      grafana_team { 'example-team2':
+        ensure           => absent,
+        grafana_url      => 'http://localhost:3000',
+        grafana_user     => 'admin',
+        grafana_password => 'admin',
+      }
       grafana_team { 'example-team-on-org':
         ensure           => absent,
         grafana_url      => 'http://localhost:3000',
@@ -131,8 +167,21 @@ describe 'grafana_team' do
         grafana_user     => 'admin',
         grafana_password => 'admin',
       }
+      grafana_dashboard { 'example-dashboard2':
+        ensure           => absent,
+        grafana_url      => 'http://localhost:3000',
+        grafana_user     => 'admin',
+        grafana_password => 'admin',
+      }
+      grafana_folder { 'example-folder':
+        ensure           => absent,
+        uid              => 'example-folder',
+        grafana_url      => 'http://localhost:3000',
+        grafana_user     => 'admin',
+        grafana_password => 'admin',
+      }
       grafana_organization { 'example-organization':
-        ensure => absent,
+        ensure           => absent,
         grafana_url      => 'http://localhost:3000',
         grafana_user     => 'admin',
         grafana_password => 'admin',

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -78,7 +78,6 @@ describe 'grafana' do
         describe 'install plugin with plugin url' do
           it { is_expected.to contain_grafana_plugin('grafana-plugin-url').with(ensure: 'present', plugin_url: 'https://grafana.com/api/plugins/grafana-simple-json-datasource/versions/latest/download') }
         end
-
       end
 
       context 'with parameter install_method is set to repo' do

--- a/spec/unit/puppet/provider/grafana_plugin/grafana_cli_spec.rb
+++ b/spec/unit/puppet/provider/grafana_plugin/grafana_cli_spec.rb
@@ -11,7 +11,6 @@ describe provider_class do
 
   describe '#instances' do
     let(:plugins_ls_two) do
-      # rubocop:disable Layout/TrailingWhitespace
       <<-PLUGINS
 installed plugins:
 grafana-simple-json-datasource @ 1.3.4
@@ -85,6 +84,4 @@ Restart grafana after installing plugins . <service grafana-server restart>
       expect(provider).to have_received(:grafana_cli).with('--pluginUrl', 'https://grafana.com/api/plugins/grafana-simple-json-datasource/versions/latest/download', 'plugins', 'install', 'grafana-simple-json-datasource')
     end
   end
-
-
 end

--- a/spec/unit/puppet/type/grafana_plugin_spec.rb
+++ b/spec/unit/puppet/type/grafana_plugin_spec.rb
@@ -22,5 +22,4 @@ describe Puppet::Type.type(:grafana_plugin) do
     plugin[:plugin_url] = 'https://grafana.com/api/plugins/grafana-simple-json-datasource/versions/latest/download'
     expect(plugin[:plugin_url]).to eq('https://grafana.com/api/plugins/grafana-simple-json-datasource/versions/latest/download')
   end
-
 end

--- a/spec/unit/puppet/type/grafana_team_type_spec.rb
+++ b/spec/unit/puppet/type/grafana_team_type_spec.rb
@@ -7,6 +7,7 @@ describe Puppet::Type.type(:grafana_team) do
       grafana_url: 'http://example.com',
       grafana_user: 'admin',
       grafana_password: 'admin',
+      home_dashboard_folder: 'bar',
       home_dashboard: 'foo_dashboard',
       organization: 'foo_organization'
     )
@@ -23,6 +24,7 @@ describe Puppet::Type.type(:grafana_team) do
       expect(gteam[:grafana_user]).to eq('admin')
       expect(gteam[:grafana_password]).to eq('admin')
       expect(gteam[:grafana_url]).to eq('http://example.com')
+      expect(gteam[:home_dashboard_folder]).to eq('bar')
       expect(gteam[:home_dashboard]).to eq('foo_dashboard')
       expect(gteam[:organization]).to eq('foo_organization')
     end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
In my environment we might have the dashboard `Node Metrics` in numerous folders with different user teams associated to each folder with slightly difference dashboards in each folder.  This change allows the team home dashboard to be selected by a specific folder rather than just picking the first dashboard that matches the name which might be the wrong dashboard in wrong folder and in my case would get permission denied for our users if wrong dashboard ended up matching the previous search logic that just looked for first dashboard to match a given name.