### PR TITLE
bump default grafana version for FreeBSD

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,6 +3,7 @@ grafana::archive_source: ~
 grafana::cfg_location: '/etc/grafana/grafana.ini'
 grafana::cfg: {}
 grafana::ldap_cfg: ~
+grafana::ldap_cfg_location: '/etc/grafana/ldap.toml'
 grafana::container_cfg: false
 grafana::container_params: {}
 grafana::docker_image: 'grafana/grafana'

--- a/data/family/FreeBSD.yaml
+++ b/data/family/FreeBSD.yaml
@@ -3,5 +3,5 @@ grafana::cfg_location: '/usr/local/etc/grafana.ini'
 grafana::data_dir: '/var/db/grafana'
 grafana::install_method: 'repo'
 grafana::manage_package_repo: false
-grafana::package_name: 'grafana7'
+grafana::package_name: 'grafana8'
 grafana::service_name: 'grafana'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -91,7 +91,7 @@ class grafana::config {
 
     $ldap_cfg_toml = inline_template($template_body.join(''))
 
-    file { '/etc/grafana/ldap.toml':
+    file { $grafana::ldap_cfg_location:
       ensure  => file,
       content => $ldap_cfg_toml,
       owner   => 'grafana',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -138,6 +138,7 @@ class grafana (
   String $cfg_location,
   Hash $cfg,
   Optional[Variant[Hash,Array]] $ldap_cfg,
+  String $ldap_cfg_location,
   Boolean $container_cfg,
   Hash $container_params,
   String $docker_image,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -138,7 +138,7 @@ class grafana (
   String $cfg_location,
   Hash $cfg,
   Optional[Variant[Hash,Array]] $ldap_cfg,
-  String $ldap_cfg_location,
+  Stdlib::Absolutepath $ldap_cfg_location,
   Boolean $container_cfg,
   Hash $container_params,
   String $docker_image,


### PR DESCRIPTION
Latest current version: www/grafana8 (https://www.freshports.org/www/grafana8)
Tested: FreeBSD 13.0

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
