### PR TITLE
bump default grafana version for FreeBSD

### DIFF
--- a/data/family/FreeBSD.yaml
+++ b/data/family/FreeBSD.yaml
@@ -4,5 +4,5 @@ grafana::provisioning_dir: '/usr/local/etc/grafana/provisioning'
 grafana::data_dir: '/var/db/grafana'
 grafana::install_method: 'repo'
 grafana::manage_package_repo: false
-grafana::package_name: 'grafana7'
+grafana::package_name: 'grafana8'
 grafana::service_name: 'grafana'


### PR DESCRIPTION
Latest current version: www/grafana8 (https://www.freshports.org/www/grafana8)
Tested: FreeBSD 13.0

Obsoletes PR: https://github.com/voxpupuli/puppet-grafana/pull/256

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
