### PR TITLE
Set grafana.ini owner to root with packages

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -27,7 +27,7 @@ class grafana::config {
         ensure  => file,
         path    => $grafana::cfg_location,
         content => template('grafana/config.ini.erb'),
-        owner   => 'grafana',
+        owner   => 'root',
         group   => 'grafana',
         notify  => Class['grafana::service'],
       }


### PR DESCRIPTION
This is what the package has by default. Since grafana can still read the file, this should not be an issue.

I noticed that after an apt upgrade Puppet changed the owner again. This prevents needsless restarts.