### PR TITLE
Add support for HTTP operation PATCH to fix grafana_membership

### DIFF
--- a/lib/puppet/provider/grafana.rb
+++ b/lib/puppet/provider/grafana.rb
@@ -51,6 +51,9 @@ class Puppet::Provider::Grafana < Puppet::Provider
       request = Net::HTTP::Get.new(uri.request_uri)
     when 'DELETE'
       request = Net::HTTP::Delete.new(uri.request_uri)
+    when 'PATCH'
+      request = Net::HTTP::Patch.new(uri.request_uri)
+      request.body = data.to_json
     else
       raise Puppet::Error, format('Unsupported HTTP operation %s', operation)
     end


### PR DESCRIPTION
#### Pull Request (PR) description
This allows the HTTP operation PATCH required for resource type grafana_membership (https://github.com/voxpupuli/puppet-grafana/blob/master/lib/puppet/provider/grafana_membership/grafana.rb#L176). 

#### This Pull Request (PR) fixes the following issues
n/a