### PR TITLE
Fix dashboard api call in grafana_dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,7 +673,7 @@ grafana_dashboard { 'example_dashboard':
 }
 ```
 
-`content` must be valid JSON, and is parsed before imported.
+`content` must be valid JSON, and is parsed before imported. You can use the JSON generated with the share/export functionality or from the API call to /dashboards/uid but must remove the fields "id", "uid", "title" and "version" to make the resource call idempotent.
 `grafana_user` and `grafana_password` are optional, and required when
 authentication is enabled in Grafana. `grafana_api_path` is optional, and only used when using sub-paths for the API. `organization` is optional, and used when creating a dashboard for a specific organization.
 `folder` is an optional parameter, but the folder resource must exist.

--- a/lib/puppet/provider/grafana_dashboard/grafana.rb
+++ b/lib/puppet/provider/grafana_dashboard/grafana.rb
@@ -115,7 +115,7 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
 
     begin
       # Cache the dashboard's content
-      @dashboard = JSON.parse(response.body)['dashboard'].reject { |k, _| k =~ %r{^id|uid|version|title$} }
+      @dashboard = JSON.parse(response.body)['dashboard']
     rescue JSON::ParserError
       raise format('Fail to parse dashboard %s: %s', resource[:title], response.body)
     end

--- a/lib/puppet/provider/grafana_dashboard/grafana.rb
+++ b/lib/puppet/provider/grafana_dashboard/grafana.rb
@@ -161,7 +161,7 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
   end
 
   def destroy
-    db = dashboards.find { |x| x['title'] ==  resource[:title] }
+    db = dashboards.find { |x| x['title'] == resource[:title] }
     raise Puppet::Error, format('Failed to delete dashboard %s, dashboard not found', resource[:title]) if db.nil?
     response = send_request('DELETE', format('%s/dashboards/uid/%s', resource[:grafana_api_path], db['uid']))
 

--- a/lib/puppet/provider/grafana_dashboard/grafana.rb
+++ b/lib/puppet/provider/grafana_dashboard/grafana.rb
@@ -104,12 +104,13 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
 
   # Return the dashboard matching with the resource's title
   def find_dashboard
-    return unless dashboards.find { |x| x['title'] == resource[:title] }
+    db = dashboards.find { |x| x['title'] == resource[:title] }
+    return if db.nil?
 
-    response = send_request('GET', format('%s/dashboards/uid/%s', resource[:grafana_api_path], slug))
+    response = send_request('GET', format('%s/dashboards/uid/%s', resource[:grafana_api_path], db['uid']))
 
     if response.code != '200'
-      raise format('Fail to retrieve dashboard %s (HTTP response: %s/%s)', resource[:title], response.code, response.body)
+      raise format('Fail to retrieve dashboard %s by uid %s (HTTP response: %s/%s)', resource[:title], db['uid'], response.code, response.body)
     end
 
     begin

--- a/lib/puppet/provider/grafana_dashboard/grafana.rb
+++ b/lib/puppet/provider/grafana_dashboard/grafana.rb
@@ -115,7 +115,7 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
 
     begin
       # Cache the dashboard's content
-      @dashboard = JSON.parse(response.body)['dashboard']
+      @dashboard = JSON.parse(response.body)['dashboard'].reject { |k, _| k =~ %r{^id|uid|version|title$} }
     rescue JSON::ParserError
       raise format('Fail to parse dashboard %s: %s', resource[:title], response.body)
     end
@@ -132,8 +132,8 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
 
     data = {
       dashboard: dashboard.merge('title' => resource[:title],
-                                 #'id' => @dashboard ? @dashboard['id'] : nil,
-                                 #'uid' => slug, This alters the UID of the existing dashboards in unwanted ways
+                                 'id' => @dashboard ? @dashboard['id'] : nil,
+                                 'uid' => @dashboard ? @dashboard['uid'] : nil,
                                  'version' => @dashboard ? @dashboard['version'] + 1 : 0),
       folderId: @folder ? @folder['id'] : nil,
       overwrite: !@dashboard.nil?
@@ -149,7 +149,7 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
   end
 
   def content
-    @dashboard.reject { |k, _| k =~ %r{^uid|version|title$} }
+    @dashboard.reject { |k, _| k =~ %r{^id|uid|version|title$} }
   end
 
   def content=(value)

--- a/lib/puppet/provider/grafana_dashboard/grafana.rb
+++ b/lib/puppet/provider/grafana_dashboard/grafana.rb
@@ -161,7 +161,7 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
   end
 
   def destroy
-    db = dashboards.find { |x| x['title'] == slug }
+    db = dashboards.find { |x| x['title'] ==  resource[:title] }
     raise Puppet::Error, format('Failed to delete dashboard %s, dashboard not found', resource[:title]) if db.nil?
     response = send_request('DELETE', format('%s/dashboards/uid/%s', resource[:grafana_api_path], db['uid']))
 

--- a/lib/puppet/provider/grafana_dashboard/grafana.rb
+++ b/lib/puppet/provider/grafana_dashboard/grafana.rb
@@ -133,7 +133,7 @@ Puppet::Type.type(:grafana_dashboard).provide(:grafana, parent: Puppet::Provider
     data = {
       dashboard: dashboard.merge('title' => resource[:title],
                                  'id' => @dashboard ? @dashboard['id'] : nil,
-                                 'uid' => @dashboard ? @dashboard['uid'] : nil,
+                                 'uid' => @dashboard ? @dashboard['uid'] : slug,
                                  'version' => @dashboard ? @dashboard['version'] + 1 : 0),
       folderId: @folder ? @folder['id'] : nil,
       overwrite: !@dashboard.nil?

--- a/spec/acceptance/grafana_folder_spec.rb
+++ b/spec/acceptance/grafana_folder_spec.rb
@@ -139,7 +139,7 @@ supported_versions.each do |grafana_version|
       end
 
       it 'folder contains dashboard' do
-        shell('curl --user admin:admin http://localhost:3000/api/dashboards/uid/example-dashboard') do |f|
+        shell('curl --user admin:admin http://localhost:3000/api/search?query=example-dashboard') do |f|
           expect(f.stdout).to match(%r{"folderId":1})
         end
       end


### PR DESCRIPTION
#### Pull Request (PR) description
The grafana_dashboard function was changed from using the old deprecated api to the recommended endpoint using the uid. However, the module still passed the dashboard title to the API instead of the uid, always resulting in a dashboard not found error. This PR fixes the problem.

#### This Pull Request (PR) fixes the following issues
Fixes #261 