### PR TITLE
rubocop: disable rubocop comments

### DIFF
--- a/spec/unit/puppet/type/grafana_datasource_type_spec.rb
+++ b/spec/unit/puppet/type/grafana_datasource_type_spec.rb
@@ -63,11 +63,11 @@ describe Puppet::Type.type(:grafana_datasource) do
       expect(gdatasource[:type]).to eq('elasticsearch')
       expect(gdatasource[:organization]).to eq('test_org')
       expect(gdatasource[:access_mode]).to eq(:proxy)
-      expect(gdatasource[:is_default]).to eq(:true) # rubocop:disable Lint/BooleanSymbol
-      expect(gdatasource[:basic_auth]).to eq(:true) # rubocop:disable Lint/BooleanSymbol
+      expect(gdatasource[:is_default]).to eq(:true)
+      expect(gdatasource[:basic_auth]).to eq(:true)
       expect(gdatasource[:basic_auth_user]).to eq('user')
       expect(gdatasource[:basic_auth_password]).to eq('password')
-      expect(gdatasource[:with_credentials]).to eq(:true) # rubocop:disable Lint/BooleanSymbol
+      expect(gdatasource[:with_credentials]).to eq(:true)
       expect(gdatasource[:database]).to eq('test_db')
       expect(gdatasource[:user]).to eq('db_user')
       expect(gdatasource[:password]).to eq('db_password')

--- a/spec/unit/puppet/type/grafana_notification_type_spec.rb
+++ b/spec/unit/puppet/type/grafana_notification_type_spec.rb
@@ -45,8 +45,8 @@ describe Puppet::Type.type(:grafana_notification) do
       expect(gnotification[:name]).to eq('foo')
       expect(gnotification[:grafana_url]).to eq('http://example.com')
       expect(gnotification[:type]).to eq('email')
-      expect(gnotification[:is_default]).to eq(:true) # rubocop:disable Lint/BooleanSymbol
-      expect(gnotification[:send_reminder]).to eq(:true) # rubocop:disable Lint/BooleanSymbol
+      expect(gnotification[:is_default]).to eq(:true)
+      expect(gnotification[:send_reminder]).to eq(:true)
       expect(gnotification[:frequency]).to eq('20m')
       expect(gnotification[:settings]).to eq(adresses: 'test@example.com')
     end


### PR DESCRIPTION
This fixes the master branch. The errors were introduced with the latest voxpupuli-test release.