### PR TITLE
Accept `Sensitive` `cfg`

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Manages the Grafana configuration file. Grafana comes with its own default
 settings in a different configuration file (/opt/grafana/current/conf/defaults.ini),
 therefore this module does not supply any defaults.
 
-This parameter only accepts a hash as its value. Keys with hashes as values will
+This parameter only accepts a `Hash` (or `Sensitive[Hash]`) as its value. Keys with hashes as values will
 generate sections, any other values are just plain values. The example below will
 result in...
 
@@ -154,6 +154,8 @@ Some minor notes:
 * The order of the keys in this hash is the same as they will be written to the
   configuration file. So settings that do not fall under a section will have to
   come before any sections in the hash.
+* If your configuration contains secrets you want hidden in Puppet log output and reports
+  use a `Sensitive[Hash]` instead of a normal `Hash`
 
 #### `ldap_cfg`
 

--- a/lib/puppet/provider/grafana_dashboard_permission/grafana.rb
+++ b/lib/puppet/provider/grafana_dashboard_permission/grafana.rb
@@ -218,7 +218,7 @@ Puppet::Type.type(:grafana_dashboard_permission).provide(:grafana, parent: Puppe
     end
   end
 
-  def permission_data(destroy = false) # rubocop:disable Style/OptionalBooleanParameter
+  def permission_data(destroy = false)
     raise format('Unknown dashboard: %s', resource[:dashboard]) unless dashboard
 
     endpoint = format('%s/dashboards/id/%s/permissions', grafana_api_path, dashboard[:id])

--- a/lib/puppet/provider/grafana_datasource/grafana.rb
+++ b/lib/puppet/provider/grafana_datasource/grafana.rb
@@ -147,7 +147,7 @@ Puppet::Type.type(:grafana_datasource).provide(:grafana, parent: Puppet::Provide
     save_datasource
   end
 
-  # rubocop:disable Style/PredicateName
+  # rubocop:disable Naming/PredicateName
   def is_default
     datasource[:is_default]
   end
@@ -156,7 +156,7 @@ Puppet::Type.type(:grafana_datasource).provide(:grafana, parent: Puppet::Provide
     resource[:is_default] = value
     save_datasource
   end
-  # rubocop:enable Style/PredicateName
+  # rubocop:enable Naming/PredicateName
 
   def basic_auth
     datasource[:basic_auth]

--- a/lib/puppet/type/grafana_user.rb
+++ b/lib/puppet/type/grafana_user.rb
@@ -41,7 +41,7 @@ Puppet::Type.newtype(:grafana_user) do
 
   newproperty(:password) do
     desc 'The password for the user'
-    def insync?(_is) # rubocop:disable Naming/MethodParameterName
+    def insync?(_is)
       provider.check_password
     end
   end
@@ -60,7 +60,7 @@ Puppet::Type.newtype(:grafana_user) do
     defaultto :false
   end
 
-  def set_sensitive_parameters(sensitive_parameters) # rubocop:disable Style/AccessorMethodName
+  def set_sensitive_parameters(sensitive_parameters) # rubocop:disable Naming/AccessorMethodName
     parameter(:password).sensitive = true if parameter(:password)
     super(sensitive_parameters)
   end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -136,7 +136,7 @@
 class grafana (
   Optional[String] $archive_source,
   String $cfg_location,
-  Hash $cfg,
+  Variant[Hash,Sensitive[Hash]] $cfg,
   Optional[Variant[Hash,Array]] $ldap_cfg,
   Boolean $container_cfg,
   Hash $container_params,

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -305,6 +305,40 @@ describe 'grafana' do
 
           it { is_expected.to contain_file('/etc/grafana/ldap.toml').with_content(ldap_expected) }
         end
+
+        context 'with Sensitive `cfg`' do
+          let(:params) do
+            {
+              cfg: sensitive(
+                {
+                  'database' => {
+                    'type' => 'postgres',
+                    'host' => 'db.example.com:5432',
+                    'name' => 'grafana',
+                    'user' => 'grafana',
+                    'password' => 'hunter2',
+                  },
+                }
+              )
+            }
+          end
+
+          let(:expected) do
+            <<~CONTENT
+              # This file is managed by Puppet, any changes will be overwritten
+
+
+              [database]
+              host = db.example.com:5432
+              name = grafana
+              password = hunter2
+              type = postgres
+              user = grafana
+            CONTENT
+          end
+
+          it { is_expected.to contain_file('grafana.ini').with_content(sensitive(expected)) }
+        end
       end
 
       context 'multiple ldap configuration' do

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -17,7 +17,6 @@ describe 'grafana' do
         it { is_expected.to contain_class('grafana::service') }
       end
 
-      # rubocop:disable RSpec/EmptyExampleGroup
       context 'with parameter install_method is set to package' do
         let(:params) do
           {
@@ -461,7 +460,6 @@ describe 'grafana' do
           end
         end
       end
-      # rubocop:enable RSpec/EmptyExampleGroup
     end
   end
 end


### PR DESCRIPTION
Useful when your configuration contains passwords you don't want to
expose in your puppet logs and reports.