### PR TITLE
Accept `Sensitive` `ldap_cfg`

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ or manually using one of the following:
   # AIO or PE puppetserver
   /opt/puppet/bin/puppetserver gem install toml
 ```
+##### secrets
+
+LDAP configuration usually contains secrets. If you want to stop these being leaked in logs and reports,
+the `ldap_cfg` parameter will optionally accept the `Sensitive` data type.
 
 ##### cfg note
 
@@ -198,7 +202,7 @@ be enabled in the main configuration file. Enable it in cfg with:
 #### Example LDAP config
 
 ```
-ldap_cfg => {
+ldap_cfg => Sensitive({
   servers => [
     { host            => 'ldapserver1.domain1.com',
       port            => 636,
@@ -214,16 +218,16 @@ ldap_cfg => {
     surname   => 'sn',
     username  => 'sAMAccountName',
     member_of => 'memberOf',
-    email     => 'email',
+    email     => 'mail',
   }
-},
+}),
 ```
 
 If you want to connect to multiple LDAP servers using different configurations,
 use an array to enwrap the configurations as shown below.
 
 ```
-ldap_cfg => [
+ldap_cfg => Sensitive([
   {
     servers => [
       {
@@ -241,7 +245,7 @@ ldap_cfg => [
       surname   => 'sn',
       username  => 'sAMAccountName',
       member_of => 'memberOf',
-      email     => 'email',
+      email     => 'mail',
     },
     'servers.group_mappings' => [
       {
@@ -278,7 +282,7 @@ ldap_cfg => [
       }
     ],
   },
-]
+])
 
 
 #####
@@ -297,7 +301,7 @@ grafana::ldap_cfg:
       surname: sn
       username: sAMAccountName
       member_of: memberOf
-      email: email
+      email: mail
     servers.group_mappings:
       - group_dn: cn=grafana_viewers,ou=groups,dc=domain1,dc=com
         org_role: Viewer

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -137,7 +137,7 @@ class grafana (
   Optional[String] $archive_source,
   String $cfg_location,
   Variant[Hash,Sensitive[Hash]] $cfg,
-  Optional[Variant[Hash,Array]] $ldap_cfg,
+  Optional[Variant[Hash,Array[Hash],Sensitive[Hash],Sensitive[Array[Hash]]]] $ldap_cfg,
   Boolean $container_cfg,
   Hash $container_params,
   String $docker_image,

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -273,7 +273,7 @@ describe 'grafana' do
                   'surname' => 'sn',
                   'username' => 'sAMAccountName',
                   'member_of' => 'memberOf',
-                  'email' => 'email'
+                  'email' => 'mail'
                 }
               }
             }
@@ -296,7 +296,7 @@ describe 'grafana' do
                           "use_ssl = true\n"\
                           "\n"\
                           "[servers.attributes]\n"\
-                          "email = \"email\"\n"\
+                          "email = \"mail\"\n"\
                           "member_of = \"memberOf\"\n"\
                           "name = \"givenName\"\n"\
                           "surname = \"sn\"\n"\
@@ -359,7 +359,7 @@ describe 'grafana' do
                     'surname' => 'sn',
                     'username' => 'sAMAccountName',
                     'member_of' => 'memberOf',
-                    'email' => 'email'
+                    'email' => 'mail'
                   }
                 },
                 {
@@ -374,7 +374,7 @@ describe 'grafana' do
                     'surname' => 'sn',
                     'username' => 'sAMAccountName',
                     'member_of' => 'memberOf',
-                    'email' => 'email'
+                    'email' => 'mail'
                   }
                 }
               ]
@@ -388,7 +388,7 @@ describe 'grafana' do
                           "use_ssl = true\n"\
                           "\n"\
                           "[servers.attributes]\n"\
-                          "email = \"email\"\n"\
+                          "email = \"mail\"\n"\
                           "member_of = \"memberOf\"\n"\
                           "name = \"givenName\"\n"\
                           "surname = \"sn\"\n"\
@@ -401,7 +401,7 @@ describe 'grafana' do
                           "use_ssl = true\n"\
                           "\n"\
                           "[servers.attributes]\n"\
-                          "email = \"email\"\n"\
+                          "email = \"mail\"\n"\
                           "member_of = \"memberOf\"\n"\
                           "name = \"givenName\"\n"\
                           "surname = \"sn\"\n"\
@@ -409,6 +409,65 @@ describe 'grafana' do
                           "\n"
 
           it { is_expected.to contain_file('/etc/grafana/ldap.toml').with_content(ldap_expected) }
+        end
+      end
+
+      context 'with Sensitive `ldap_cfg`' do
+        let(:ldap_cfg) do
+          {
+            'servers' => [
+              { 'host' => 'server1a server1b',
+                'use_ssl' => true,
+                'search_filter' => '(sAMAccountName=%s)',
+                'search_base_dns' => ['dc=domain1,dc=com'] }
+            ],
+            'servers.attributes' => {
+              'name' => 'givenName',
+              'surname' => 'sn',
+              'username' => 'sAMAccountName',
+              'member_of' => 'memberOf',
+              'email' => 'mail'
+            }
+          }
+        end
+
+        let(:expected) do
+          <<~CONTENT
+
+            [[servers]]
+            host = "server1a server1b"
+            search_base_dns = ["dc=domain1,dc=com"]
+            search_filter = "(sAMAccountName=%s)"
+            use_ssl = true
+
+            [servers.attributes]
+            email = "mail"
+            member_of = "memberOf"
+            name = "givenName"
+            surname = "sn"
+            username = "sAMAccountName"
+
+          CONTENT
+        end
+
+        context 'Sensitive[Hash]' do
+          let(:params) do
+            {
+              ldap_cfg: sensitive(ldap_cfg)
+            }
+          end
+
+          it { is_expected.to contain_file('/etc/grafana/ldap.toml').with_content(sensitive(expected)) }
+        end
+
+        context 'Sensitive[Array[Hash]]' do
+          let(:params) do
+            {
+              ldap_cfg: sensitive([ldap_cfg])
+            }
+          end
+
+          it { is_expected.to contain_file('/etc/grafana/ldap.toml').with_content(sensitive(expected)) }
         end
       end
 


### PR DESCRIPTION
Similar to 04fcd9111a17535853623da4c14f73b84407c4a9 this commit adds
support for `Sensitive` to the `ldap_cfg` parameter.

I've also fixed the LDAP examples `email` attibute to be `mail` which
is correct for Active Directory (where `username` is `sAMAccountName`)