### PR TITLE
Fix `grafana_user` and switch to using `flush`

### DIFF
--- a/lib/puppet/provider/grafana_user/grafana.rb
+++ b/lib/puppet/provider/grafana_user/grafana.rb
@@ -5,9 +5,12 @@ require 'json'
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'grafana'))
 
 Puppet::Type.type(:grafana_user).provide(:grafana, parent: Puppet::Provider::Grafana) do
-  desc 'Support for Grafana users'
+  desc 'Manages local Grafana users'
 
-  defaultfor kernel: 'Linux'
+  def initialize(value = {})
+    super(value)
+    @property_flush = {}
+  end
 
   def users
     response = send_request('GET', format('%s/users', resource[:grafana_api_path]))
@@ -48,8 +51,7 @@ Puppet::Type.type(:grafana_user).provide(:grafana, parent: Puppet::Provider::Gra
   end
 
   def name=(value)
-    resource[:name] = value
-    save_user
+    @property_flush[:login] = value
   end
 
   def full_name
@@ -57,8 +59,7 @@ Puppet::Type.type(:grafana_user).provide(:grafana, parent: Puppet::Provider::Gra
   end
 
   def full_name=(value)
-    resource[:full_name] = value
-    save_user
+    @property_flush[:name] = value
   end
 
   def email
@@ -66,8 +67,7 @@ Puppet::Type.type(:grafana_user).provide(:grafana, parent: Puppet::Provider::Gra
   end
 
   def email=(value)
-    resource[:email] = value
-    save_user
+    @property_flush[:email] = value
   end
 
   def theme
@@ -75,8 +75,7 @@ Puppet::Type.type(:grafana_user).provide(:grafana, parent: Puppet::Provider::Gra
   end
 
   def theme=(value)
-    resource[:theme] = value
-    save_user
+    @property_flush[:theme] = value
   end
 
   def password
@@ -84,43 +83,50 @@ Puppet::Type.type(:grafana_user).provide(:grafana, parent: Puppet::Provider::Gra
   end
 
   def password=(value)
-    resource[:password] = value
-    save_user
+    @property_flush[:password] = value
   end
 
-  # rubocop:disable Style/PredicateName
+  # rubocop:disable Naming/PredicateName
   def is_admin
     user[:is_admin]
   end
 
   def is_admin=(value)
-    resource[:is_admin] = value
-    save_user
+    @property_flush[:is_admin] = value
   end
-  # rubocop:enable Style/PredicateName
+  # rubocop:enable Naming/PredicateName
 
-  def save_user
-    data = {
-      login: resource[:name],
-      name: resource[:full_name],
-      email: resource[:email],
-      password: resource[:password],
-      theme: resource[:theme],
-      isGrafanaAdmin: (resource[:is_admin] == :true)
-    }
-
-    if user.nil?
-      response = send_request('POST', format('%s/admin/users', resource[:grafana_api_path]), data)
-    else
-      data[:id] = user[:id]
-      send_request 'PUT', format('%s/admin/users/%s/password', resource[:grafana_api_path], user[:id]), password: data.delete(:password)
-      send_request 'PUT', format('%s/admin/users/%s/permissions', resource[:grafana_api_path], user[:id]), isGrafanaAdmin: data.delete(:isGrafanaAdmin)
-      response = send_request('PUT', format('%s/users/%s', resource[:grafana_api_path], user[:id]), data)
+  def flush
+    if @property_flush[:ensure] == :absent
+      delete_user
+      return
     end
 
-    raise format('Failed to create user %s (HTTP response: %s/%s)', resource[:name], response.code, response.body) if response.code != '200'
+    password = @property_flush.delete(:password)
+    is_admin = @property_flush.delete(:is_admin)
 
-    self.user = nil
+    unless @property_flush.empty?
+      debug('Updating user properties')
+
+      # If we don't include the login name, and email is being updated, then login will be reset to match the email address!
+      data = @property_flush.merge({ login: resource[:name] })
+      response = send_request('PUT', format('%s/users/%s', resource[:grafana_api_path], user[:id]), data)
+      raise format('Failed to update properties for user %s (HTTP response: %s/%s', resource[:name], response.code, response.body) if response.code != '200'
+    end
+
+    if password
+      debug('Updating user password')
+      response = send_request 'PUT', format('%s/admin/users/%s/password', resource[:grafana_api_path], user[:id]), password: password
+      raise format('Failed to update password for user %s (HTTP response: %s/%s', resource[:name], response.code, response.body) if response.code != '200'
+    end
+
+    update_admin_flag(is_admin) unless is_admin.nil?
+  end
+
+  def update_admin_flag(is_admin)
+    debug("Setting isGrafanaAdmin to #{is_admin}")
+    response = send_request 'PUT', format('%s/admin/users/%s/permissions', resource[:grafana_api_path], user[:id]), isGrafanaAdmin: (is_admin == :true)
+    raise format('Failed to update isGrafanaAdmin for user %s (HTTP response: %s/%s', resource[:name], response.code, response.body) if response.code != '200'
   end
 
   def check_password
@@ -146,11 +152,29 @@ Puppet::Type.type(:grafana_user).provide(:grafana, parent: Puppet::Provider::Gra
   end
 
   def create
-    save_user
+    data = {
+      login: resource[:name],
+      name: resource[:full_name],
+      email: resource[:email],
+      theme: resource[:theme],
+      password: resource[:password] || random_password,
+    }.compact
+
+    debug('Creating user')
+
+    response = send_request('POST', format('%s/admin/users', resource[:grafana_api_path]), data)
+    raise format('Failed to create user %s (HTTP response: %s/%s)', resource[:name], response.code, response.body) if response.code != '200'
+
+    update_admin_flag(resource[:is_admin]) unless resource[:is_admin].nil?
+  end
+
+  def random_password
+    require 'securerandom'
+    SecureRandom.hex(64)
   end
 
   def destroy
-    delete_user
+    @property_flush[:ensure] = :absent
   end
 
   def exists?

--- a/lib/puppet/type/grafana_user.rb
+++ b/lib/puppet/type/grafana_user.rb
@@ -35,7 +35,7 @@ Puppet::Type.newtype(:grafana_user) do
     desc 'The password for the Grafana server'
   end
 
-  newparam(:full_name) do
+  newproperty(:full_name) do
     desc 'The full name of the user.'
   end
 
@@ -57,7 +57,6 @@ Puppet::Type.newtype(:grafana_user) do
   newproperty(:is_admin) do
     desc 'Whether the user is a grafana admin'
     newvalues(:true, :false)
-    defaultto :false
   end
 
   def set_sensitive_parameters(sensitive_parameters) # rubocop:disable Naming/AccessorMethodName

--- a/spec/acceptance/grafana_user_spec.rb
+++ b/spec/acceptance/grafana_user_spec.rb
@@ -25,19 +25,99 @@ supported_versions.each do |grafana_version|
       end
     end
 
-    it 'runs successfully' do
-      pp = <<-EOS
-      grafana_user { 'user1':
-        grafana_url       => 'http://localhost:3000',
-        grafana_user      => 'admin',
-        grafana_password  => 'admin',
-        full_name         => 'John Doe',
-        password          => 'Us3r5ecret',
-        email             => 'john@example.com',
-      }
-      EOS
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-PUPPET
+        grafana_user { 'user1':
+          grafana_url      => 'http://localhost:3000',
+          grafana_user     => 'admin',
+          grafana_password => 'admin',
+          full_name        => 'John Doe',
+          password         => 'Us3r5ecret',
+          email            => 'john@example.com',
+        }
+        PUPPET
+      end
+    end
+
+    describe 'advanced use' do
+      describe 'creating an admin' do
+        it_behaves_like 'an idempotent resource' do
+          let(:manifest) do
+            <<-PUPPET
+            grafana_user { 'admin1':
+              grafana_url      => 'http://localhost:3000',
+              grafana_user     => 'admin',
+              grafana_password => 'admin',
+              full_name        => 'Admin User',
+              password         => 'Admin5ecret',
+              email            => 'admin@example.com',
+              is_admin         => true,
+            }
+            PUPPET
+          end
+        end
+      end
+
+      describe 'updating a user password with new admin user' do
+        it_behaves_like 'an idempotent resource' do
+          let(:manifest) do
+            <<-PUPPET
+            grafana_user { 'user1':
+              grafana_url      => 'http://localhost:3000',
+              grafana_user     => 'admin1',
+              grafana_password => 'Admin5ecret',
+              password         => 'newpassword',
+            }
+            PUPPET
+          end
+        end
+      end
+
+      describe 'Turning a user into an admin' do
+        it_behaves_like 'an idempotent resource' do
+          let(:manifest) do
+            <<-PUPPET
+            grafana_user { 'user1':
+              grafana_url      => 'http://localhost:3000',
+              grafana_user     => 'admin1',
+              grafana_password => 'Admin5ecret',
+              is_admin         => true,
+            }
+            PUPPET
+          end
+        end
+      end
+
+      describe 'updating full_name' do
+        it_behaves_like 'an idempotent resource' do
+          let(:manifest) do
+            <<-PUPPET
+            grafana_user { 'user1':
+              grafana_url      => 'http://localhost:3000',
+              grafana_user     => 'admin1',
+              grafana_password => 'Admin5ecret',
+              full_name        => 'My new Admin user',
+            }
+            PUPPET
+          end
+        end
+      end
+
+      describe 'deleting a user' do
+        it_behaves_like 'an idempotent resource' do
+          let(:manifest) do
+            <<-PUPPET
+            grafana_user { 'admin1':
+              ensure           => absent,
+              grafana_url      => 'http://localhost:3000',
+              grafana_user     => 'user1',
+              grafana_password => 'newpassword',
+            }
+            PUPPET
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Previously `save_user` was being called once per changed property and
calls were also being made to update user properties, password and the
admin flag regardless of whether these properties needed updating.

Using `flush` is more efficient.

* `full_name` is fixed (it was previously a parameter instead of a property).
* When a user is created, `is_admin` is correctly set in a single Puppet run.
* Properties can be managed individually.
* Instead of making `password` mandatory, (when creating a user), if
  `password` isn't specified, a random one is used.

Fixes #121