### PR TITLE
Fix performance of `grafana_user`

### DIFF
--- a/spec/acceptance/grafana_user_spec.rb
+++ b/spec/acceptance/grafana_user_spec.rb
@@ -40,6 +40,33 @@ supported_versions.each do |grafana_version|
       end
     end
 
+    describe 'managing 100 users' do
+      it_behaves_like 'an idempotent resource' do
+        let(:manifest) do
+          <<-PUPPET
+          grafana_user { range('testuser00', 'testuser99'):
+            ensure           => present,
+            grafana_url      => 'http://localhost:3000',
+            grafana_user     => 'admin',
+            grafana_password => 'admin',
+          }
+          PUPPET
+        end
+      end
+      it_behaves_like 'an idempotent resource' do
+        let(:manifest) do
+          <<-PUPPET
+          grafana_user { range('testuser00', 'testuser99'):
+            ensure           => absent,
+            grafana_url      => 'http://localhost:3000',
+            grafana_user     => 'admin',
+            grafana_password => 'admin',
+          }
+          PUPPET
+        end
+      end
+    end
+
     describe 'advanced use' do
       describe 'creating an admin' do
         it_behaves_like 'an idempotent resource' do


### PR DESCRIPTION
Previously, the number of API calls to look up the details of a single user was equal to `1 + the number of existing users`.
This made managing multiple users exponentially slow.

The way the types in this module are written, (with the Grafana API user credentials being parameters of each resource), we can't implement `prefetch` to fetch all users just once; but we can change the implementation to directly lookup the user we're trying to manage.

This is _much_ faster!