### PR TITLE
Add toml feature

### DIFF
--- a/lib/puppet/feature/toml.rb
+++ b/lib/puppet/feature/toml.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require 'puppet/util/feature'
+
+Puppet.features.add(:toml, libs: 'toml')

--- a/lib/puppet/type/grafana_ldap_config.rb
+++ b/lib/puppet/type/grafana_ldap_config.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-require 'toml'
 require 'puppet/parameter/boolean'
 
 Puppet::Type.newtype(:grafana_ldap_config) do
+  confine feature: :toml
+
   @doc = 'Manage Grafana LDAP configuration'
   @toml_header = <<~EOF
     #


### PR DESCRIPTION
Rather than having an explicit require on toml, this adds a feature for which which makes Puppet understand the relationship.

I don't have the setup to test this myself now, but in theory this should work.