### PR TITLE
Encode API path as it can contain non-ASCII characters

### DIFF
--- a/lib/puppet/provider/grafana.rb
+++ b/lib/puppet/provider/grafana.rb
@@ -2,7 +2,6 @@
 
 #    Copyright 2015 Mirantis, Inc.
 #
-require 'cgi'
 require 'json'
 require 'net/http'
 
@@ -26,19 +25,11 @@ class Puppet::Provider::Grafana < Puppet::Provider
   # Return a Net::HTTP::Response object
   def send_request(operation = 'GET', path = '', data = nil, search_path = {})
     request = nil
-    encoded_search = ''
 
-    if URI.respond_to?(:encode_www_form)
-      encoded_search = URI.encode_www_form(search_path)
-    else
-      # Ideally we would have use URI.encode_www_form but it isn't
-      # available with Ruby 1.8.x that ships with CentOS 6.5.
-      encoded_search = search_path.to_a.map do |x|
-        x.map { |y| CGI.escape(y.to_s) }.join('=')
-      end
-      encoded_search = encoded_search.join('&')
-    end
-    uri = URI.parse format('%s://%s:%d%s?%s', grafana_scheme, grafana_host, grafana_port, path, encoded_search)
+    encoded_path = path.split('/').map { |p| URI.encode_www_form_component(p) }.join('/')
+    encoded_search = URI.encode_www_form(search_path)
+
+    uri = URI.parse format('%s://%s:%d%s?%s', grafana_scheme, grafana_host, grafana_port, encoded_path, encoded_search)
 
     case operation.upcase
     when 'POST'

--- a/lib/puppet/provider/grafana_organization/grafana.rb
+++ b/lib/puppet/provider/grafana_organization/grafana.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'json'
-require 'erb'
 
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'grafana'))
 
@@ -10,7 +9,7 @@ Puppet::Type.type(:grafana_organization).provide(:grafana, parent: Puppet::Provi
 
   # https://grafana.com/docs/grafana/latest/http_api/org/#get-organization-by-name
   def get_org_by_name(org_name)
-    response = send_request('GET', format('%s/orgs/name/%s', resource[:grafana_api_path], ERB::Util.url_encode(org_name)))
+    response = send_request('GET', format('%s/orgs/name/%s', resource[:grafana_api_path], org_name))
 
     case response.code
     when '404'

--- a/spec/acceptance/grafana_user_spec.rb
+++ b/spec/acceptance/grafana_user_spec.rb
@@ -161,7 +161,7 @@ supported_versions.each do |grafana_version|
                 },
               }
 
-              grafana_organization { ['testorg1','testorg2','testorg3']:
+              grafana_organization { ['testorg1','testorg2','test org3']:
                 ensure           => present,
                 grafana_url      => 'http://localhost:3000',
                 grafana_user     => 'admin',
@@ -182,9 +182,9 @@ supported_versions.each do |grafana_version|
                 grafana_user     => 'admin',
                 grafana_password => 'admin',
                 organizations    => {
-                  'testorg1' => 'admin',
-                  'testorg2' => 'viewer',
-                  'testorg3' => 'Editor',
+                  'testorg1'   => 'admin',
+                  'testorg2'   => 'viewer',
+                  'test org3'  => 'Editor',
                 },
               }
               PUPPET
@@ -202,9 +202,9 @@ supported_versions.each do |grafana_version|
                 grafana_user     => 'admin',
                 grafana_password => 'admin',
                 organizations    => {
-                  'testorg1' => 'viewer',
-                  'testorg2' => 'editor',
-                  'testorg3' => 'admin',
+                  'testorg1'   => 'viewer',
+                  'testorg2'   => 'editor',
+                  'test org3'  => 'admin',
                 },
               }
               PUPPET


### PR DESCRIPTION
#### Pull Request (PR) description
API path can contains space and possibly other on-ASCII characters. eg in #286 the default organization is called `Main Org.` in order to find the the orgID we hit the api `/api/orgs/name/Main Org.`

I also removed the legacy code for ruby 1.8. I don't think it's in use anymore.

#### This Pull Request (PR) fixes the following issues
