### PR TITLE
Refactor `grafana_datasource` and add `uid` property

### DIFF
--- a/lib/puppet/type/grafana_folder.rb
+++ b/lib/puppet/type/grafana_folder.rb
@@ -48,6 +48,9 @@ Puppet::Type.newtype(:grafana_folder) do
 
   newproperty(:permissions, array_matching: :all) do
     desc 'The permissions of the folder'
+    def insync?(is)
+      is.sort_by { |k| k['permission'] } == should.sort_by { |k| k['permission'] }
+    end
   end
 
   autorequire(:service) do

--- a/spec/acceptance/grafana_datasource_spec.rb
+++ b/spec/acceptance/grafana_datasource_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+supported_versions.each do |grafana_version|
+  describe "grafana_datasource with Grafana version #{grafana_version}" do
+    prepare_host
+    context 'setup grafana server' do
+      it 'runs successfully' do
+        pp = <<-EOS
+        class { 'grafana':
+          version => "#{grafana_version}",
+          cfg => {
+            security => {
+              admin_user     => 'admin',
+              admin_password => 'admin'
+            }
+          }
+        }
+        EOS
+        prepare_host
+
+        apply_manifest(pp, catch_failures: true)
+        apply_manifest(pp, catch_changes: true)
+      end
+    end
+
+    describe 'prometheus ds' do
+      context 'without basic auth' do
+        it_behaves_like 'an idempotent resource' do
+          let(:manifest) do
+            <<-PUPPET
+            grafana_datasource { 'prometheus prom1.example.com':
+              grafana_url      => 'http://localhost:3000',
+              grafana_user     => 'admin',
+              grafana_password => 'admin',
+              type             => 'prometheus',
+              url              => 'https://prom1.example.com',
+              access_mode      => 'proxy',
+              json_data        => {
+                'httpMethod'   => 'POST',
+                'timeInterval' => '10s',
+              },
+            }
+            PUPPET
+          end
+        end
+      end
+
+      if Gem::Version.new(grafana_version) > Gem::Version.new('9')
+        context 'with basic auth in secure json data' do
+          let(:manifest) do
+            <<-PUPPET
+              grafana_datasource { 'prometheus2':
+                grafana_url          => 'http://localhost:3000',
+                grafana_user         => 'admin',
+                grafana_password     => 'admin',
+                type                 => 'prometheus',
+                url                  => 'https://prom2.example.com',
+                access_mode          => 'proxy',
+                json_data            => {
+                  'httpMethod'       => 'POST',
+                  'timeInterval'     => '10s',
+                },
+                secure_json_data     => {
+                  'basicAuthPassword' => 'prom_password',
+                },
+                basic_auth_user      => 'prom_user',
+              }
+            PUPPET
+          end
+
+          it 'works with no errors' do
+            apply_manifest_on(default, manifest, catch_failures: true)
+          end
+
+          it 'is idempotent' do
+            pending('secure_json_data is not returned by API')
+            apply_manifest_on(default, manifest, catch_changes: true)
+          end
+        end
+      else
+        context 'with basic auth in legacy field' do
+          it_behaves_like 'an idempotent resource' do
+            let(:manifest) do
+              <<-PUPPET
+              grafana_datasource { 'prometheus2':
+                grafana_url          => 'http://localhost:3000',
+                grafana_user         => 'admin',
+                grafana_password     => 'admin',
+                type                 => 'prometheus',
+                url                  => 'https://prom2.example.com',
+                access_mode          => 'proxy',
+                json_data            => {
+                  'httpMethod'       => 'POST',
+                  'timeInterval'     => '10s',
+                },
+                basic_auth_user      => 'prom_user',
+                basic_auth_password  => 'prom_password',
+              }
+              PUPPET
+            end
+          end
+        end
+      end
+    end
+
+    describe 'influxdb ds' do
+      if Gem::Version.new(grafana_version) > Gem::Version.new('9')
+        context 'with password in secure_json_data' do
+          let(:manifest) do
+            <<-PUPPET
+              grafana_datasource { 'influxdb':
+                grafana_url      => 'http://localhost:3000',
+                grafana_user     => 'admin',
+                grafana_password => 'admin',
+                type             => 'influxdb',
+                url              => 'http://localhost:8086',
+                access_mode      => 'proxy',
+                user             => 'admin',
+                secure_json_data => {
+                  'password' => '1nFlux5ecret',
+                },
+                database         => 'mydb',
+              }
+            PUPPET
+          end
+
+          it 'works with no errors' do
+            apply_manifest_on(default, manifest, catch_failures: true)
+          end
+
+          it 'is idempotent' do
+            pending('secure_json_data is not returned by API')
+            apply_manifest_on(default, manifest, catch_changes: true)
+          end
+        end
+      else
+        context 'with password in legacy field' do
+          it_behaves_like 'an idempotent resource' do
+            let(:manifest) do
+              <<-PUPPET
+              grafana_datasource { 'influxdb':
+                grafana_url      => 'http://localhost:3000',
+                grafana_user     => 'admin',
+                grafana_password => 'admin',
+                type             => 'influxdb',
+                url              => 'http://localhost:8086',
+                access_mode      => 'proxy',
+                user             => 'admin',
+                password         => '1nFlux5ecret',
+                database         => 'mydb',
+              }
+              PUPPET
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/acceptance/supported_versions.rb
+++ b/spec/support/acceptance/supported_versions.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 def supported_versions
-  %w[6.0.0 7.0.0 8.0.0]
+  %w[6.0.0 7.0.0 8.0.0 9.1.6]
 end


### PR DESCRIPTION
Refactor `grafana_datasource`

Property defaults are removed from the type and where values are needed
on datasource creation, the defaults are in the provider.

If updating an existing datasource, only properties that you want to
manage have to be specified. The API needs the post to contain several
more fields, but these can be pulled from the existing state.

`uid` is added as an optional property and, (in versions that support
it), is used when updating a datasource, (instead of updating by `id`
which has been deprecated.)

Fetching and deleting datasources by `id` has also been deprecated in
Grafana 9 so is replaced by fetching and deleting by `name`.

The managing of multiple datasources is now quicker as the previous
implementation made a number of API calls that grew exponentially with
the number of datasources.

Fixes #229

For users not using `basic_auth` or `password` properties in their
datasources restores idempotency when using Grafana 9 (see #289)

(From Grafana 9 onwards, users must use `secure_json_data` but this is
not idempotent and making it behave 100% correctly is currently
impossible as the Grafana API purposefully never exposes this data.)

There are still a number of issues open around using datasources in more
than one organization.  None of these have been addressed in this
commit.