### PR TITLE
Fix default PGP key

### DIFF
--- a/.msync.yml
+++ b/.msync.yml
@@ -2,4 +2,4 @@
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
-modulesync_config_version: '5.3.0'
+modulesync_config_version: '5.4.0'

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :test do
   gem 'voxpupuli-test', '~> 5.4',   :require => false
   gem 'coveralls',                  :require => false
   gem 'simplecov-console',          :require => false
-  gem 'puppet_metadata', '~> 1.0',  :require => false
+  gem 'puppet_metadata', '~> 2.0',  :require => false
   gem 'toml',                       :require => false
 end
 

--- a/data/family/Debian.yaml
+++ b/data/family/Debian.yaml
@@ -1,5 +1,5 @@
 ---
 grafana::install_method: 'repo'
 grafana::repo_url: 'https://packages.grafana.com/oss/deb'
-grafana::repo_key_id: '4E40DDF6D76E284A4A6780E48C8C34C524098CB6'
+grafana::repo_key_id: '0E22EB88E39E12277A7760AE9E439B102CF3C0C6'
 grafana::sysconfig_location: '/etc/default/grafana-server'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,7 +53,7 @@
 #   Defaults to https://packages.grafana.com/gpg.key.
 #
 # @param repo_key_id When using 'repo' install_method, the repo_key_id of the repo_gpg_key_url key on Debian based systems.
-#   Defaults to 4E40DDF6D76E284A4A6780E48C8C34C524098CB6.
+#   Defaults to 0E22EB88E39E12277A7760AE9E439B102CF3C0C6.
 #
 # @param repo_release Optional value, needed on Debian based systems.
 #   If repo name is set to custom, used to identify the release of the repo. No default value.


### PR DESCRIPTION
According to https://packages.grafana.com/:
> The GPG key used to sign the APT repository (fingerprint
> 4E40DDF6D76E284A4A6780E48C8C34C524098CB6) was rotated on 2023-01-12 and
> replaced with a new key with fingerprint
> 0E22EB88E39E12277A7760AE9E439B102CF3C0C6.

Update the key accordingly.
