### PR TITLE
Update repo urls

### DIFF
--- a/data/family/Debian.yaml
+++ b/data/family/Debian.yaml
@@ -1,5 +1,5 @@
 ---
 grafana::install_method: 'repo'
-grafana::repo_url: 'https://packages.grafana.com/oss/deb'
+grafana::repo_url: 'https://apt.grafana.com'
 grafana::repo_key_id: '0E22EB88E39E12277A7760AE9E439B102CF3C0C6'
 grafana::sysconfig_location: '/etc/default/grafana-server'

--- a/data/family/RedHat.yaml
+++ b/data/family/RedHat.yaml
@@ -1,4 +1,4 @@
 ---
 grafana::install_method: 'repo'
-grafana::repo_url: 'https://packages.grafana.com/oss/rpm'
+grafana::repo_url: 'https://rpm.grafana.com'
 grafana::sysconfig_location: '/etc/sysconfig/grafana-server'

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -94,7 +94,7 @@ describe 'grafana' do
         when 'Debian'
           describe 'install apt repo dependencies first' do
             it { is_expected.to contain_class('apt') }
-            it { is_expected.to contain_apt__source('grafana').with(release: 'stable', repos: 'main', location: 'https://packages.grafana.com/oss/deb') }
+            it { is_expected.to contain_apt__source('grafana').with(release: 'stable', repos: 'main', location: 'https://apt.grafana.com') }
             it { is_expected.to contain_apt__source('grafana').that_comes_before('Package[grafana]') }
           end
 
@@ -107,7 +107,7 @@ describe 'grafana' do
           end
         when 'RedHat'
           describe 'yum repo dependencies first' do
-            it { is_expected.to contain_yumrepo('grafana-stable').with(baseurl: 'https://packages.grafana.com/oss/rpm', gpgkey: 'https://packages.grafana.com/gpg.key', enabled: 1) }
+            it { is_expected.to contain_yumrepo('grafana-stable').with(baseurl: 'https://rpm.grafana.com', gpgkey: 'https://packages.grafana.com/gpg.key', enabled: 1) }
             it { is_expected.to contain_yumrepo('grafana-stable').that_comes_before('Package[grafana]') }
           end
 


### PR DESCRIPTION
#### Pull Request (PR) description
Grafana Labs updated their repository structure and replaced their generic packages.grafana.com with distribution specific URLs.
This PR sets the new repository URLs

#### This Pull Request (PR) fixes the following issues
Fixes #278

Refs #151