### PR TITLE
Update the GPG key for Grafana's APT repository

### DIFF
--- a/data/family/Debian.yaml
+++ b/data/family/Debian.yaml
@@ -1,5 +1,5 @@
 ---
 grafana::install_method: 'repo'
 grafana::repo_url: 'https://apt.grafana.com'
-grafana::repo_key_id: '0E22EB88E39E12277A7760AE9E439B102CF3C0C6'
+grafana::repo_key_id: 'B53AE77BADB630A683046005963FA27710458545'
 grafana::sysconfig_location: '/etc/default/grafana-server'


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

The GPG keys previously used to sign the APT repository (fingerprint 4E40DDF6D76E284A4A6780E48C8C34C524098CB6 0E22EB88E39E12277A7760AE9E439B102CF3C0C6) were rotated on 2023-01-12 and 2023-08-24 respectively, and replaced with a new key with fingerprint B53AE77BADB630A683046005963FA27710458545.

So updating the GPG Key with new ID.

Reference - https://apt.grafana.com/

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
