### PR TITLE
Drop EoL Debian 10 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,7 +21,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10",
         "11"
       ]
     },


### PR DESCRIPTION
I checked the code and there weren't any debian 10 related snippets.