### PR TITLE
Create subpaths for provisioning_datasources

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -82,6 +82,7 @@ The following parameters are available in the `grafana` class:
 * [`repo_release`](#-grafana--repo_release)
 * [`repo_url`](#-grafana--repo_url)
 * [`plugins`](#-grafana--plugins)
+* [`provisioning_dir`](#-grafana--provisioning_dir)
 * [`provisioning_dashboards`](#-grafana--provisioning_dashboards)
 * [`provisioning_datasources`](#-grafana--provisioning_datasources)
 * [`provisioning_dashboards_file`](#-grafana--provisioning_dashboards_file)
@@ -251,6 +252,14 @@ Plugins to be passed to `create_resources`, wraps around the
 
 Default value: `{}`
 
+##### <a name="-grafana--provisioning_dir"></a>`provisioning_dir`
+
+Data type: `Stdlib::Absolutepath`
+
+Path to the grafana provisioning dir e.g /etc/grafana/provisioning
+
+Default value: `'/etc/grafana/provisioning'`
+
 ##### <a name="-grafana--provisioning_dashboards"></a>`provisioning_dashboards`
 
 Data type: `Hash`
@@ -273,21 +282,21 @@ Default value: `{}`
 
 ##### <a name="-grafana--provisioning_dashboards_file"></a>`provisioning_dashboards_file`
 
-Data type: `String`
+Data type: `Stdlib::Absolutepath`
 
 Fully qualified path to place the provisioning file
 for dashboards, only used if provisioning_dashboards is specified.
 
-Default value: `'/etc/grafana/provisioning/dashboards/puppetprovisioned.yaml'`
+Default value: `"${provisioning_dir}/dashboards/puppetprovisioned.yaml"`
 
 ##### <a name="-grafana--provisioning_datasources_file"></a>`provisioning_datasources_file`
 
-Data type: `String`
+Data type: `Stdlib::Absolutepath`
 
 Fully qualified path to place the provisioning file
 for datasources, only used if provisioning_datasources is specified.
 
-Default value: `'/etc/grafana/provisioning/datasources/puppetprovisioned.yaml'`
+Default value: `"${provisioning_dir}/datasources/puppetprovisioned.yaml"`
 
 ##### <a name="-grafana--create_subdirs_provisioning"></a>`create_subdirs_provisioning`
 

--- a/data/family/FreeBSD.yaml
+++ b/data/family/FreeBSD.yaml
@@ -1,5 +1,6 @@
 ---
 grafana::cfg_location: '/usr/local/etc/grafana.ini'
+grafana::provisioning_dir: '/usr/local/etc/grafana/provisioning'
 grafana::data_dir: '/var/db/grafana'
 grafana::install_method: 'repo'
 grafana::manage_package_repo: false

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -161,6 +161,17 @@ class grafana::config {
     if (length($pdatasources) >= 1) {
       # template uses:
       #   - pdatasources
+
+      $datasources_provisioning_dir = "${grafana::provisioning_dir}/datasources"
+
+      file { $datasources_provisioning_dir:
+        ensure => directory,
+        owner  => 'grafana',
+        group  => 'grafana',
+        mode   => '0750',
+        before => File[$grafana::provisioning_datasources_file],
+      }
+
       file { $grafana::provisioning_datasources_file:
         ensure    => file,
         owner     => 'grafana',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,6 +68,9 @@
 #   Plugins to be passed to `create_resources`, wraps around the
 #   `grafana_plugin` resource.
 #
+# @param provisioning_dir
+#   Path to the grafana provisioning dir e.g /etc/grafana/provisioning
+#
 # @param provisioning_dashboards
 #   Dashboards to provision into grafana. grafana > v5.0.0
 #   required. Will be converted into YAML and used by grafana to
@@ -167,8 +170,9 @@ class grafana (
   Hash $plugins = {},
   Hash $provisioning_dashboards = {},
   Hash $provisioning_datasources = {},
-  String $provisioning_dashboards_file = '/etc/grafana/provisioning/dashboards/puppetprovisioned.yaml',
-  String $provisioning_datasources_file = '/etc/grafana/provisioning/datasources/puppetprovisioned.yaml',
+  Stdlib::Absolutepath $provisioning_dir = '/etc/grafana/provisioning',
+  Stdlib::Absolutepath $provisioning_dashboards_file = "${provisioning_dir}/dashboards/puppetprovisioned.yaml",
+  Stdlib::Absolutepath $provisioning_datasources_file = "${provisioning_dir}/datasources/puppetprovisioned.yaml",
   Boolean $create_subdirs_provisioning = false,
   Optional[Hash] $sysconfig = undef,
   Hash[String[1], Hash] $ldap_servers = {},

--- a/spec/classes/grafana_spec.rb
+++ b/spec/classes/grafana_spec.rb
@@ -532,6 +532,42 @@ describe 'grafana' do
         end
       end
 
+      context 'provisioning_datasources defined' do
+        let(:params) do
+          {
+            version: '11.0.0',
+            provisioning_datasources: {
+              apiVersion: 1,
+              datasources: [
+                {
+                  name: 'Prometheus',
+                  type: 'prometheus',
+                  access: 'proxy',
+                  url: 'http://localhost:9090/',
+                  isDefault: true,
+                }
+              ]
+            }
+          }
+        end
+
+        it do
+          puppetprovisioned_datasources_path = case facts[:osfamily]
+                                               when 'FreeBSD'
+                                                 '/usr/local/etc/grafana/provisioning/datasources/puppetprovisioned.yaml'
+                                               else
+                                                 '/etc/grafana/provisioning/datasources/puppetprovisioned.yaml'
+                                               end
+
+          expect(subject).to contain_file(puppetprovisioned_datasources_path).with(
+            ensure: 'file',
+            owner: 'grafana',
+            group: 'grafana',
+            mode: '0640'
+          )
+        end
+      end
+
       context 'sysconfig environment variables' do
         let(:params) do
           {


### PR DESCRIPTION
The tests are not failing @bastelfreak and me are thinks that a test task already created the folders.

but if you ran an basic example on a real machine you will get:

```
Could not set 'file' on ensure: No such file or directory - A directory component in /etc/grafana/provisioning/datasources/puppetprovisioned.yaml20240607-2077526-prxolk.lock does not exist or is a dangling symbolic link (file: …/grafana/manifests/config.pp, line: 164)
Wrapped exception:
No such file or directory - A directory component in /etc/grafana/provisioning/datasources/puppetprovisioned.yaml20240607-2077526-prxolk.lock does not exist or is a dangling symbolic link
```

after a look into that system the /etc/grafana/provisioning/datasources/ doesn't exists.

this PR should fix that and create the folder