### PR TITLE
move toml dependency to avoid toml missing when not needing ldap feature

### DIFF
--- a/lib/puppet/type/grafana_ldap_config.rb
+++ b/lib/puppet/type/grafana_ldap_config.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'toml'
 require 'puppet/parameter/boolean'
 
 Puppet::Type.newtype(:grafana_ldap_config) do
@@ -156,6 +155,7 @@ Puppet::Type.newtype(:grafana_ldap_config) do
   end
 
   def eval_generate
+    require 'toml'
     ldap_servers = should_content
 
     if !ldap_servers.nil? && !ldap_servers.empty?


### PR DESCRIPTION
#### Pull Request (PR) description
This pull request tries to address installing the module in a restricted environment (no gem install available for toml) without failing as the LDAP feature is not needed in my scenario.

#### This Pull Request (PR) fixes the following issues
Fixes #338
