### PR TITLE
Add Alerting and Contact points

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,28 @@ which is not part of grafana's syntax. This option will be extracted
 from the hash, and used to "source" a directory of dashboards. See
 **Advanced Usage** for details.
 
+#### `provisioning_alerting_source`
+
+A Source path to an alerting folder. This will be used to "source" a directory 
+of alerts. All YAML and JSON Files in this Folder 
+will be copied to the grafana provisioning directory (default: /etc/grafana/provisioning/alerting).
+See **Advanced Usage** for details.
+
+See [provisioning grafana alerting](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/file-provisioning/) 
+for details and example config files.
+
+##### `provisioning_contact_points`
+
+A Hash which is converted to YAML for grafana to provision data
+sources. See [provisioning grafana alerting](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/file-provisioning/ for
+details and example config file. Requires grafana > v5.0.0.
+
+This is very useful with Hiera as you can provide a yaml
+hash/dictionary which will effectively 'passthrough' to grafana. See
+**Advanced Usage** for examples.
+
+You also have the option to use **provisioning_alerting_source** to "source" it with the directory of alerts.
+
 #### `provisioning_dashboards_file`
 
 A String that is used as the target file name for the dashabords
@@ -429,6 +451,18 @@ A String that is used as the target file name for the datasources
 provisioning file. This way the module can be used to generate placeholder
 files so password can be sepecified in a different iteration, avoiding them
 to be put in the module code.
+
+#### `provisioning_contact_points_file`
+
+A String that is used as the target file name for the contact point
+provisioning file. This way the module can be used to generate placeholder
+files so password can be sepecified in a different iteration, avoiding them
+to be put in the module code.
+
+#### `provisioning_alerting_dir`
+
+A String to the alerting provisioning directory. This way the module can copy the 
+alerts and contact points into the right path.
 
 ##### `rpm_iteration`
 
@@ -1013,7 +1047,8 @@ provisioning](http://docs.grafana.org/administration/provisioning/).
 
 This module will provision grafana by placing yaml files into
 `/etc/grafana/provisioning/datasources` and
-`/etc/grafana/provisioning/dashboards` by default.
+`/etc/grafana/provisioning/dashboards`  and 
+`/etc/grafana/provisioning/alerting` by default.
 
 ##### Example datasource
 
@@ -1157,6 +1192,58 @@ Dashboards known to be "provisionable":
 Dashboards known not to be "provisionable":
 
 * [HTTP Services Status](https://grafana.com/dashboards/4859)
+
+#### Example Alert
+
+You need to set 
+`grafana::provisioning_alerting_source: puppet:///path/to/alerting` in puppet.
+This is the the path to "source" the alert YAMLs or JSONs.
+
+See [grafana import alert rules](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/file-provisioning/#import-alert-rules) for examples of alert rule YAMLs.
+
+#### Example Contact point
+
+A puppet hash example for Prometheus. The module will place the hash
+as a yaml file into `/etc/gafana/provisioning/alerting/puppetprovisioned-contact-points.yaml`.
+
+```puppet
+class { 'grafana':
+  provisioning_contact_points => {
+    apiVersion      => 1,
+    contactPoints   => [
+      { 
+        orgId       => 1,
+        name        => 'cp_1'
+        receivers   => {
+            uid                     => 'first_uid',
+            type                    => 'prometheus-alertmanager',
+            disableResolveMessage   => false,
+            settings                => {
+                url => 'http://test:9000'
+            },
+        },
+      },
+    ],
+  }
+}
+```
+
+Here is the same configuration example as a hiera hash.
+
+```yaml
+grafana::provisioning_dashboards:
+    apiVersion: 1
+    contactPoints:
+        - orgId: 1
+        name: cp_1
+        receivers:
+        - uid: first_uid
+        type: prometheus-alertmanager
+        disableResolveMessage: false
+        settings:
+            url: http://test:9000
+```
+
 
 ## Tasks
 

--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ for details and example config files.
 ##### `provisioning_contact_points`
 
 A Hash which is converted to YAML for grafana to provision data
-sources. See [provisioning grafana alerting](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/file-provisioning/ for
+sources. See [provisioning grafana alerting](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/file-provisioning/) for
 details and example config file. Requires grafana > v5.0.0.
 
 This is very useful with Hiera as you can provide a yaml

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -182,5 +182,46 @@ class grafana::config {
         notify    => Class['grafana::service'],
       }
     }
+
+    # --alerts-- 
+    if ( $grafana::provisioning_alerting_source != undef ) {
+      file { $grafana::provisioning_alerting_dir:
+        ensure       => directory,
+        owner        => 'grafana',
+        group        => 'grafana',
+        mode         => '0640',
+        recurse      => true,
+        sourceselect => 'all',
+        purge        => true,
+        source       => $grafana::provisioning_alerting_source,
+        notify       => Class['grafana::service'],
+      }
+    }
+
+    # --contact_points--
+    $pcontact_points = $grafana::provisioning_contact_points
+    if (length($pcontact_points) >= 1) {
+      # template uses:
+      #   - pcontact_points
+      if (!defined(File[$grafana::provisioning_alerting_dir])) {
+        file { $grafana::provisioning_alerting_dir:
+          ensure => directory,
+          owner  => 'grafana',
+          group  => 'grafana',
+          mode   => '0750',
+        }
+      }
+
+      file { $grafana::provisioning_contact_points_file:
+        ensure    => file,
+        owner     => 'grafana',
+        group     => 'grafana',
+        mode      => '0640',
+        show_diff => false,
+        content   => epp('grafana/pcontact_points.yaml.epp'),
+        require   => File[$grafana::provisioning_alerting_dir],
+        notify    => Class['grafana::service'],
+      }
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,6 +81,15 @@
 #   required. Will be converted into YAML and used by granfana to
 #   configure datasources.
 #
+# @param provisioning_contact_points
+#   Contact points to provision into grafana, grafana > v5.0.0
+#   required. Will be converted into YAML and used by granfana to
+#   configure contact_points.
+#
+# @param provisioning_alerting_source
+#   Alerts to provision into grafana, grafana > v5.0.0
+#   required. Source Path to alert YAMLs and JSONs to copy.
+#
 # @param provisioning_dashboards_file
 #   Fully qualified path to place the provisioning file
 #   for dashboards, only used if provisioning_dashboards is specified.
@@ -88,6 +97,14 @@
 # @param provisioning_datasources_file
 #   Fully qualified path to place the provisioning file
 #   for datasources, only used if provisioning_datasources is specified.
+#
+# @param provisioning_contact_points_file
+#   Fully qualified path to place the provisioning file
+#   for contact points, only used if provisioning_contact_points is specified.
+#
+# @param provisioning_alerting_dir
+#   Fully qualified path to place the provisioning file
+#   for alerts, only used if provisioning_alerting is specified.
 #
 # @param create_subdirs_provisioning
 #   If true puppet will create any
@@ -170,9 +187,13 @@ class grafana (
   Hash $plugins = {},
   Hash $provisioning_dashboards = {},
   Hash $provisioning_datasources = {},
+  Hash $provisioning_contact_points = {},
+  Optional[Stdlib::Filesource] $provisioning_alerting_source = undef,
   Stdlib::Absolutepath $provisioning_dir = '/etc/grafana/provisioning',
   Stdlib::Absolutepath $provisioning_dashboards_file = "${provisioning_dir}/dashboards/puppetprovisioned.yaml",
   Stdlib::Absolutepath $provisioning_datasources_file = "${provisioning_dir}/datasources/puppetprovisioned.yaml",
+  Stdlib::Absolutepath $provisioning_alerting_dir = "${provisioning_dir}/alerting",
+  Stdlib::Absolutepath $provisioning_contact_points_file = "${provisioning_dir}/alerting/puppetprovisioned-contact-points.yaml",
   Boolean $create_subdirs_provisioning = false,
   Optional[Hash] $sysconfig = undef,
   Hash[String[1], Hash] $ldap_servers = {},

--- a/templates/pcontact_points.yaml.epp
+++ b/templates/pcontact_points.yaml.epp
@@ -1,0 +1,3 @@
+# This file is managed by Puppet, any changes will be overwritten
+
+<%= stdlib::to_yaml($grafana::config::pcontact_points) -%>


### PR DESCRIPTION
#### Pull Request (PR) description
<!--
This PR allows you to provision Grafana alerts and contact points. You are able to provision alerts through a source directory as YAMLs or JSONs. You are able to create Contact Points as a File in the source alerting Directory or as an Hash that will be placed as a yaml file into /etc/gafana/provisioning/alerting/puppetprovisioned-contact-points.yaml 
-->

#### This Pull Request (PR) fixes the following issues
<!--
n/a
-->
