### PR TITLE
Add parent_uid on folders + ability to move folders

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -854,6 +854,10 @@ The title of the folder
 
 UID of the folder
 
+##### `parent_uid`
+
+UID of the parent folder, if any
+
 ### <a name="grafana_ldap_config"></a>`grafana_ldap_config`
 
 Manage Grafana LDAP configuration

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -811,6 +811,7 @@ The following parameters are available in the `grafana_folder` type.
 * [`grafana_url`](#-grafana_folder--grafana_url)
 * [`grafana_user`](#-grafana_folder--grafana_user)
 * [`organization`](#-grafana_folder--organization)
+* [`parent_uid`](#-grafana_folder--parent_uid)
 * [`provider`](#-grafana_folder--provider)
 * [`title`](#-grafana_folder--title)
 * [`uid`](#-grafana_folder--uid)
@@ -840,6 +841,12 @@ The username for the Grafana server (optional)
 The organization name to create the folder on
 
 Default value: `1`
+
+##### <a name="-grafana_folder--parent_uid"></a>`parent_uid`
+
+UID of the parent folder (optional)
+
+Default value: `''`
 
 ##### <a name="-grafana_folder--provider"></a>`provider`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -854,10 +854,6 @@ The title of the folder
 
 UID of the folder
 
-##### `parent_uid`
-
-UID of the parent folder, if any
-
 ### <a name="grafana_ldap_config"></a>`grafana_ldap_config`
 
 Manage Grafana LDAP configuration

--- a/lib/puppet/provider/grafana_folder/grafana.rb
+++ b/lib/puppet/provider/grafana_folder/grafana.rb
@@ -146,7 +146,6 @@ Puppet::Type.type(:grafana_folder).provide(:grafana, parent: Puppet::Provider::G
     return unless (response.code != '200')
 
     raise format('Failed to move folder %s (HTTP response: %s/%s)', resource[:title], response.code, response.body)
-    end
   end
 
   def save_permissions(value)

--- a/lib/puppet/provider/grafana_folder/grafana.rb
+++ b/lib/puppet/provider/grafana_folder/grafana.rb
@@ -132,7 +132,7 @@ Puppet::Type.type(:grafana_folder).provide(:grafana, parent: Puppet::Provider::G
     end
   end
 
-  def move_folder(folder)
+  def move_folder
     response = send_request 'POST', format('%s/user/using/%s', resource[:grafana_api_path], fetch_organization[:id])
     raise format('Failed to switch to org %s (HTTP response: %s/%s)', fetch_organization[:id], response.code, response.body) unless response.code == '200'
 
@@ -141,7 +141,7 @@ Puppet::Type.type(:grafana_folder).provide(:grafana, parent: Puppet::Provider::G
     }
 
     response = send_request('POST', format('%s/folders/%s/move', resource[:grafana_api_path], @folder['uid']), data)
-    return unless (response.code != '200')
+    return unless response.code != '200'
 
     raise format('Failed to move folder %s (HTTP response: %s/%s)', resource[:title], response.code, response.body)
   end

--- a/lib/puppet/provider/grafana_folder/grafana.rb
+++ b/lib/puppet/provider/grafana_folder/grafana.rb
@@ -119,6 +119,7 @@ Puppet::Type.type(:grafana_folder).provide(:grafana, parent: Puppet::Provider::G
       grafana_folder = JSON.parse(response.body)
       if grafana_folder.key?('parentUid') && resource[:parent_uid] != grafana_folder.parentUid
         move_folder(folder)
+      end
 
       data = {
         folder: folder.merge('title' => resource[:title],

--- a/lib/puppet/provider/grafana_folder/grafana.rb
+++ b/lib/puppet/provider/grafana_folder/grafana.rb
@@ -117,7 +117,7 @@ Puppet::Type.type(:grafana_folder).provide(:grafana, parent: Puppet::Provider::G
       save_permissions(resource[:permissions])
     else
       grafana_folder = JSON.parse(response.body)
-      if grafana_folder.key?("parentUid") && resource[:parent_uid] != grafana_folder.parentUid
+      if grafana_folder.key?('parentUid') && resource[:parent_uid] != grafana_folder.parentUid
         move_folder(folder)
 
       data = {

--- a/lib/puppet/provider/grafana_folder/grafana.rb
+++ b/lib/puppet/provider/grafana_folder/grafana.rb
@@ -117,9 +117,7 @@ Puppet::Type.type(:grafana_folder).provide(:grafana, parent: Puppet::Provider::G
       save_permissions(resource[:permissions])
     else
       grafana_folder = JSON.parse(response.body)
-      if grafana_folder.key?('parentUid') && resource[:parent_uid] != grafana_folder.parentUid
-        move_folder(folder)
-      end
+      grafana_folder.key?('parentUid') && resource[:parent_uid] != grafana_folder.parentUid && move_folder(folder)
 
       data = {
         folder: folder.merge('title' => resource[:title],

--- a/lib/puppet/type/grafana_folder.rb
+++ b/lib/puppet/type/grafana_folder.rb
@@ -15,7 +15,7 @@ Puppet::Type.newtype(:grafana_folder) do
     desc 'UID of the folder'
   end
 
-  newparam (:parent_uid) do
+  newparam(:parent_uid) do
     desc 'UID of the parent folder (optional)'
     defaultto ''
   end

--- a/lib/puppet/type/grafana_folder.rb
+++ b/lib/puppet/type/grafana_folder.rb
@@ -15,6 +15,11 @@ Puppet::Type.newtype(:grafana_folder) do
     desc 'UID of the folder'
   end
 
+  newparam (:parent_uid) do
+    desc 'UID of the parent folder (optional)'
+    defaultto ''
+  end
+
   newparam(:grafana_url) do
     desc 'The URL of the Grafana server'
     defaultto ''

--- a/spec/acceptance/grafana_folder_spec.rb
+++ b/spec/acceptance/grafana_folder_spec.rb
@@ -42,6 +42,7 @@ supported_versions.each do |grafana_version|
         grafana_folder { 'editor-folder':
           ensure           => present,
           uid              => 'editor-folder',
+          parent_uid       => 'example-folder',
           grafana_url      => 'http://localhost:3000',
           grafana_user     => 'admin',
           grafana_password => 'admin',
@@ -97,6 +98,7 @@ supported_versions.each do |grafana_version|
       grafana_folder { 'editor-folder':
         ensure           => present,
         uid              => 'editor-folder',
+        parent_uid       => 'example-folder',
         grafana_url      => 'http://localhost:3000',
         grafana_user     => 'admin',
         grafana_password => 'admin',

--- a/spec/acceptance/grafana_folder_spec.rb
+++ b/spec/acceptance/grafana_folder_spec.rb
@@ -42,7 +42,6 @@ supported_versions.each do |grafana_version|
         grafana_folder { 'editor-folder':
           ensure           => present,
           uid              => 'editor-folder',
-          parent_uid       => 'example-folder',
           grafana_url      => 'http://localhost:3000',
           grafana_user     => 'admin',
           grafana_password => 'admin',
@@ -98,7 +97,6 @@ supported_versions.each do |grafana_version|
       grafana_folder { 'editor-folder':
         ensure           => present,
         uid              => 'editor-folder',
-        parent_uid       => 'example-folder',
         grafana_url      => 'http://localhost:3000',
         grafana_user     => 'admin',
         grafana_password => 'admin',

--- a/spec/acceptance/grafana_folder_spec.rb
+++ b/spec/acceptance/grafana_folder_spec.rb
@@ -157,18 +157,21 @@ supported_versions.each do |grafana_version|
         include grafana::validator
         grafana_folder { 'example-folder':
           ensure           => absent,
+          uid              => 'example-folder',
           grafana_url      => 'http://localhost:3000',
           grafana_user     => 'admin',
           grafana_password => 'admin',
         }
         grafana_folder { 'editor-folder':
           ensure           => absent,
+          uid              => 'editor-folder',
           grafana_url      => 'http://localhost:3000',
           grafana_user     => 'admin',
           grafana_password => 'admin',
         }
         grafana_folder { 'nomatch-folder':
           ensure           => absent,
+          uid              => 'nomatch-folder',
           grafana_url      => 'http://localhost:3000',
           grafana_user     => 'admin',
           grafana_password => 'admin',


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add a parent_uid parameter on the grafana_folder type. Equal to empty string by default, can be set to a folder UID so that the folder is a nested folder.
Add also a `move()` method to move folders from one parent folder to another.

#### This Pull Request (PR) fixes the following issues
Fixes #389
