### PR TITLE
Add retry in send_request with exponential backoff

### DIFF
--- a/lib/puppet/provider/grafana.rb
+++ b/lib/puppet/provider/grafana.rb
@@ -24,7 +24,7 @@ class Puppet::Provider::Grafana < Puppet::Provider
   end
 
   # Return a Net::HTTP::Response object
-  def send_request(operation = 'GET', path = '', data = nil, search_path = {})
+  def send_request(operation = 'GET', path = '', data = nil, search_path = {}, retries = 3)
     request = nil
     encoded_search = ''
 
@@ -61,10 +61,25 @@ class Puppet::Provider::Grafana < Puppet::Provider
     request.content_type = 'application/json'
     request.basic_auth resource[:grafana_user], resource[:grafana_password] if resource[:grafana_user] && resource[:grafana_password]
 
-    Net::HTTP.start(grafana_host, grafana_port,
-                    use_ssl: grafana_scheme == 'https',
-                    verify_mode: OpenSSL::SSL::VERIFY_NONE) do |http|
-      http.request(request)
+    attempts = 0
+
+    begin
+      attempts += 1
+      Net::HTTP.start(grafana_host, grafana_port,
+                      use_ssl: grafana_scheme == 'https',
+                      verify_mode: OpenSSL::SSL::VERIFY_NONE) do |http|
+        http.request(request)
+      end
+    rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Timeout::Error, SocketError => e
+      if attempts < retries
+        sleep_time = 2**attempts # exponential backoff
+        Puppet.debug("Grafana HTTP request failed (#{e.message}), retry #{attempts}/#{retries} in #{sleep_time}s")
+        sleep(sleep_time)
+        retry
+      else
+        Puppet.debug("Grafana HTTP request failed after #{retries} attempts: #{e.message}")
+        raise
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

This adds retries for HTTP requests in the send_request helper function with
an exponential backoff.

If there is a race condition between Grafana starting (due to many database
migrations) and listening on the HTTP port 3000 socket we might get a socket
error and the send_request method doesn't retry for grafana_datasource resources
that will try at the exact same second that grafana-server is started.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
