### PR TITLE
Fix grafana package name on FreeBSD

### DIFF
--- a/data/family/FreeBSD.yaml
+++ b/data/family/FreeBSD.yaml
@@ -4,5 +4,5 @@ grafana::provisioning_dir: '/usr/local/etc/grafana/provisioning'
 grafana::data_dir: '/var/db/grafana'
 grafana::install_method: 'repo'
 grafana::manage_package_repo: false
-grafana::package_name: 'grafana7'
+grafana::package_name: 'grafana'
 grafana::service_name: 'grafana'


### PR DESCRIPTION
Each version used to be a separate port, but nowadays there is a single www/grafana port that is updated when a new major version is released.
