### PR TITLE
Remove deprecated grafana-cli command

### DIFF
--- a/lib/puppet/provider/grafana_plugin/grafana_cli.rb
+++ b/lib/puppet/provider/grafana_plugin/grafana_cli.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Puppet::Type.type(:grafana_plugin).provide(:grafana_cli) do
-  has_command(:grafana_cli, 'grafana-cli') do
+  has_command(:grafana_cli, 'grafana cli') do
     is_optional
   end
 

--- a/lib/puppet/provider/package/grafana.rb
+++ b/lib/puppet/provider/package/grafana.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:package).provide :grafana, parent: Puppet::Provider::Package 
 
   has_feature :installable, :install_options, :uninstallable, :upgradeable, :versionable
 
-  has_command(:grafana_cli, 'grafana-cli') do
+  has_command(:grafana_cli, 'grafana cli') do
     is_optional
   end
 

--- a/spec/acceptance/grafana_plugin_spec.rb
+++ b/spec/acceptance/grafana_plugin_spec.rb
@@ -20,7 +20,7 @@ supported_versions.each do |grafana_version|
       end
 
       it 'has the plugin' do
-        shell('grafana-cli plugins ls') do |r|
+        shell('grafana cli plugins ls') do |r|
           expect(r.stdout).to match(%r{grafana-simple-json-datasource})
         end
       end
@@ -43,7 +43,7 @@ supported_versions.each do |grafana_version|
       end
 
       it 'has the plugin' do
-        shell('grafana-cli plugins ls') do |r|
+        shell('grafana cli plugins ls') do |r|
           expect(r.stdout).to match(%r{grafana-simple-json-datasource})
         end
       end


### PR DESCRIPTION
#### Pull Request (PR) description
This pull requests fixes the grafana-cli deprecation error when installing a plugin
```
Error: Execution of '/usr/sbin/grafana-cli --pluginUrl https://XXX plugins install XXX' returned 1: Deprecation warning: 'grafana-cli' is deprecated and will be removed in a future release. Use the 'grafana cli' subcommand instead.
Grafana-server Init Failed: Could not find config defaults, make sure homepath command line parameter is set or working directory is homepath
```

#### This Pull Request (PR) fixes the following issues
https://github.com/voxpupuli/puppet-grafana/issues/405
